### PR TITLE
add menu option to optionally show grid coordinates in side view; closes #102

### DIFF
--- a/lib/src/actions/actions.dart
+++ b/lib/src/actions/actions.dart
@@ -1982,6 +1982,22 @@ abstract class ShowHelixCirclesMainViewSet
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// show or hide grid coordinates in side view
+
+abstract class ShowGridCoordinatesSideViewSet
+    with BuiltJsonSerializable
+    implements Action, Built<ShowGridCoordinatesSideViewSet, ShowGridCoordinatesSideViewSetBuilder> {
+  bool get show_grid_coordinates_side_view;
+
+  /************************ begin BuiltValue boilerplate ************************/
+  factory ShowGridCoordinatesSideViewSet({bool show_grid_coordinates_side_view}) = _$ShowGridCoordinatesSideViewSet._;
+
+  ShowGridCoordinatesSideViewSet._();
+
+  static Serializer<ShowGridCoordinatesSideViewSet> get serializer => _$showGridCoordinatesSideViewSetSerializer;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // load dna sequence png
 
 abstract class LoadDnaSequenceImageUri

--- a/lib/src/reducers/app_ui_state_reducer.dart
+++ b/lib/src/reducers/app_ui_state_reducer.dart
@@ -110,6 +110,9 @@ bool warn_on_exit_if_unsaved_reducer(bool _, actions.WarnOnExitIfUnsavedSet acti
 bool show_helix_circles_main_view_reducer(bool _, actions.ShowHelixCirclesMainViewSet action) =>
     action.show_helix_circles_main_view;
 
+bool show_grid_coordinates_side_view_reducer(bool _, actions.ShowGridCoordinatesSideViewSet action) =>
+    action.show_grid_coordinates_side_view;
+
 bool display_base_offsets_of_major_ticks_reducer(bool _, actions.DisplayMajorTicksOffsetsSet action) =>
     action.show;
 
@@ -200,6 +203,9 @@ AppUIStateStorable app_ui_state_storable_reducer(AppUIStateStorable storables, a
       ..show_helix_circles_main_view =
           TypedReducer<bool, actions.ShowHelixCirclesMainViewSet>(show_helix_circles_main_view_reducer)(
               storables.show_helix_circles_main_view, action)
+      ..show_grid_coordinates_side_view =
+          TypedReducer<bool, actions.ShowGridCoordinatesSideViewSet>(show_grid_coordinates_side_view_reducer)(
+              storables.show_grid_coordinates_side_view, action)
       ..strand_paste_keep_color =
           TypedReducer<bool, actions.StrandPasteKeepColorSet>(strand_paste_keep_color_reducer)(storables.strand_paste_keep_color, action)
       ..autofit = TypedReducer<bool, actions.AutofitSet>(center_on_load_reducer)(storables.autofit, action)

--- a/lib/src/serializers.dart
+++ b/lib/src/serializers.dart
@@ -41,6 +41,7 @@ import 'state/crossover.dart';
 part 'serializers.g.dart';
 
 @SerializersFor([
+  ShowGridCoordinatesSideViewSet,
   ShowHelixCirclesMainViewSet,
   SelectModeToggle,
   SelectModesSet,

--- a/lib/src/state/app_ui_state.dart
+++ b/lib/src/state/app_ui_state.dart
@@ -104,7 +104,7 @@ abstract class AppUIStateStorable
     b.invert_y_axis = false;
     b.warn_on_exit_if_unsaved = true;
     b.show_helix_circles_main_view = true;
-    b.show_grid_coordinates_side_view = true;
+    b.show_grid_coordinates_side_view = false;
   }
 
   /************************ begin BuiltValue boilerplate ************************/

--- a/lib/src/state/app_ui_state.dart
+++ b/lib/src/state/app_ui_state.dart
@@ -77,6 +77,8 @@ abstract class AppUIStateStorable
 
   bool get show_helix_circles_main_view;
 
+  bool get show_grid_coordinates_side_view;
+
   static void _initializeBuilder(AppUIStateStorableBuilder b) {
     // This ensures that even if these keys are not in localStorage (e.g., due to upgrading),
     // then they will be populated with a default value instead of raising an exception.
@@ -102,6 +104,7 @@ abstract class AppUIStateStorable
     b.invert_y_axis = false;
     b.warn_on_exit_if_unsaved = true;
     b.show_helix_circles_main_view = true;
+    b.show_grid_coordinates_side_view = true;
   }
 
   /************************ begin BuiltValue boilerplate ************************/
@@ -224,6 +227,8 @@ abstract class AppUIState with BuiltJsonSerializable implements Built<AppUIState
   bool get warn_on_exit_if_unsaved => storables.warn_on_exit_if_unsaved;
 
   bool get show_helix_circles_main_view => storables.show_helix_circles_main_view;
+
+  bool get show_grid_coordinates_side_view => storables.show_grid_coordinates_side_view;
 
   static void _initializeBuilder(AppUIStateBuilder b) {
     b.mouseover_datas.replace([]);

--- a/lib/src/view/design_side.dart
+++ b/lib/src/view/design_side.dart
@@ -35,6 +35,7 @@ UiFactory<DesignSideProps> ConnectedDesignSide = connect<AppState, DesignSidePro
         ..grid = state.dna_design.grid
         ..grid_position_mouse_cursor = state.ui_state.side_view_grid_position_mouse_cursor
         ..mouse_svg_pos = state.ui_state.side_view_position_mouse_cursor
+        ..show_grid_coordinates = state.ui_state.show_grid_coordinates_side_view
         ..invert_y = state.ui_state.invert_y_axis;
     }
   },
@@ -53,6 +54,7 @@ mixin DesignSideProps on UiProps {
   GridPosition grid_position_mouse_cursor;
   bool invert_y;
   bool helix_change_apply_to_all;
+  bool show_grid_coordinates;
 }
 
 class DesignSideComponent extends UiComponent2<DesignSideProps> with PureComponent {
@@ -81,6 +83,7 @@ class DesignSideComponent extends UiComponent2<DesignSideProps> with PureCompone
           ..helix_change_apply_to_all = props.helix_change_apply_to_all
           ..edit_modes = props.edit_modes
           ..mouse_is_over = props.grid_position_mouse_cursor == helix.grid_position
+          ..show_grid_coordinates = props.show_grid_coordinates
           ..selected = helix_idxs_selected.contains(helix.idx)
           ..mouseover_data = helix_idx_to_mouseover_data[helix.idx]
           ..key = '${helix.position_ == null ? helix.grid_position : helix.position_}')()

--- a/lib/src/view/design_side_helix.dart
+++ b/lib/src/view/design_side_helix.dart
@@ -62,7 +62,6 @@ class DesignSideHelixComponent extends UiComponent2<DesignSideHelixProps> with P
     // of idx, which is useful for making figures in the documentation showing how the grids work
 //    bool SHOW_HELIX_COORDINATES_INSTEAD_OF_IDX = true;
     bool SHOW_HELIX_COORDINATES_INSTEAD_OF_IDX = false;
-    bool SHOW__INDEX_AND_COORDINATES = props.show_grid_coordinates;
     var temp_text_for_help_doc_figure_making;
 
     String tooltip;
@@ -94,13 +93,13 @@ class DesignSideHelixComponent extends UiComponent2<DesignSideHelixProps> with P
               ? temp_text_for_help_doc_figure_making
               : props.helix.idx.toString(),
           Dom.svgTitle()(tooltip)),
-      (Dom.text()
+      if (props.show_grid_coordinates)
+        (Dom.text()
             ..style = {'font-size': 10}
             ..dominantBaseline = 'text-before-edge'
             ..textAnchor = 'middle'
-            ..y = '10'
-            ..key = 'text')(
-          SHOW__INDEX_AND_COORDINATES ? temp_text_for_help_doc_figure_making : "",),
+            ..y = constants.HELIX_RADIUS_SIDE_PIXELS/2
+            ..key = 'text')(temp_text_for_help_doc_figure_making),
           (Dom.svgTitle()(tooltip)),
     ];
 

--- a/lib/src/view/design_side_helix.dart
+++ b/lib/src/view/design_side_helix.dart
@@ -63,17 +63,18 @@ class DesignSideHelixComponent extends UiComponent2<DesignSideHelixProps> with P
 //    bool SHOW_HELIX_COORDINATES_INSTEAD_OF_IDX = true;
     bool SHOW_HELIX_COORDINATES_INSTEAD_OF_IDX = false;
     var temp_text_for_help_doc_figure_making;
+    String grid_position_str;
 
     String tooltip;
     if (props.grid.is_none()) {
       var pos = props.helix.position3d();
       int precision = constants.NUM_DIGITS_PRECISION_POSITION_DISPLAYED;
       tooltip = '${pos.x.toStringAsFixed(precision)}, ${pos.y.toStringAsFixed(precision)}';
-      temp_text_for_help_doc_figure_making = '${pos.x.toStringAsFixed(1)},${pos.y.toStringAsFixed(1)}';
+      grid_position_str = '${pos.x.toStringAsFixed(1)},${pos.y.toStringAsFixed(1)}';
     } else {
       var pos = props.helix.grid_position;
       tooltip = '${pos.h}, ${pos.v}';
-      temp_text_for_help_doc_figure_making = tooltip.replaceAll(' ', '');
+      grid_position_str = tooltip.replaceAll(' ', '');
     }
 
     var children = [
@@ -90,7 +91,7 @@ class DesignSideHelixComponent extends UiComponent2<DesignSideHelixProps> with P
             ..onClick = ((e) => this._handle_click(e, helix))
             ..key = 'text')(
           SHOW_HELIX_COORDINATES_INSTEAD_OF_IDX
-              ? temp_text_for_help_doc_figure_making
+              ? grid_position_str
               : props.helix.idx.toString(),
           Dom.svgTitle()(tooltip)),
       if (props.show_grid_coordinates)
@@ -99,7 +100,7 @@ class DesignSideHelixComponent extends UiComponent2<DesignSideHelixProps> with P
             ..dominantBaseline = 'text-before-edge'
             ..textAnchor = 'middle'
             ..y = constants.HELIX_RADIUS_SIDE_PIXELS/2
-            ..key = 'text')(temp_text_for_help_doc_figure_making),
+            ..key = 'text')(grid_position_str),
           (Dom.svgTitle()(tooltip)),
     ];
 

--- a/lib/src/view/design_side_helix.dart
+++ b/lib/src/view/design_side_helix.dart
@@ -33,6 +33,7 @@ mixin DesignSideHelixProps on UiProps {
   bool selected;
   bool mouse_is_over;
   bool helix_change_apply_to_all;
+  bool show_grid_coordinates;
   MouseoverData mouseover_data;
   BuiltSet<EditModeChoice> edit_modes;
   Grid grid;
@@ -61,6 +62,7 @@ class DesignSideHelixComponent extends UiComponent2<DesignSideHelixProps> with P
     // of idx, which is useful for making figures in the documentation showing how the grids work
 //    bool SHOW_HELIX_COORDINATES_INSTEAD_OF_IDX = true;
     bool SHOW_HELIX_COORDINATES_INSTEAD_OF_IDX = false;
+    bool SHOW__INDEX_AND_COORDINATES = props.show_grid_coordinates;
     var temp_text_for_help_doc_figure_making;
 
     String tooltip;
@@ -92,6 +94,14 @@ class DesignSideHelixComponent extends UiComponent2<DesignSideHelixProps> with P
               ? temp_text_for_help_doc_figure_making
               : props.helix.idx.toString(),
           Dom.svgTitle()(tooltip)),
+      (Dom.text()
+            ..style = {'font-size': 10}
+            ..dominantBaseline = 'text-before-edge'
+            ..textAnchor = 'middle'
+            ..y = '10'
+            ..key = 'text')(
+          SHOW__INDEX_AND_COORDINATES ? temp_text_for_help_doc_figure_making : "",),
+          (Dom.svgTitle()(tooltip)),
     ];
 
 //    print('checking mouseover data');

--- a/lib/src/view/menu.dart
+++ b/lib/src/view/menu.dart
@@ -55,8 +55,8 @@ UiFactory<MenuProps> ConnectedMenu = connect<AppState, MenuProps>(
     ..display_major_tick_widths_all_helices = state.ui_state.display_major_tick_widths_all_helices
     ..invert_y_axis = state.ui_state.invert_y_axis
     ..show_helix_circles_main_view = state.ui_state.show_helix_circles_main_view
-    ..warn_on_exit_if_unsaved = state.ui_state.warn_on_exit_if_unsaved)
-    ..show_grid_coordinates_side_view = state.ui_state.show_grid_coordinates_side_view,
+    ..warn_on_exit_if_unsaved = state.ui_state.warn_on_exit_if_unsaved
+    ..show_grid_coordinates_side_view = state.ui_state.show_grid_coordinates_side_view),
   // Used for component test.
   forwardRef: true,
 )(Menu);

--- a/lib/src/view/menu.dart
+++ b/lib/src/view/menu.dart
@@ -55,7 +55,8 @@ UiFactory<MenuProps> ConnectedMenu = connect<AppState, MenuProps>(
     ..display_major_tick_widths_all_helices = state.ui_state.display_major_tick_widths_all_helices
     ..invert_y_axis = state.ui_state.invert_y_axis
     ..show_helix_circles_main_view = state.ui_state.show_helix_circles_main_view
-    ..warn_on_exit_if_unsaved = state.ui_state.warn_on_exit_if_unsaved),
+    ..warn_on_exit_if_unsaved = state.ui_state.warn_on_exit_if_unsaved)
+    ..show_grid_coordinates_side_view = state.ui_state.show_grid_coordinates_side_view,
   // Used for component test.
   forwardRef: true,
 )(Menu);
@@ -86,6 +87,7 @@ mixin MenuPropsMixin on UiProps {
   bool invert_y_axis;
   bool warn_on_exit_if_unsaved;
   bool show_helix_circles_main_view;
+  bool show_grid_coordinates_side_view;
 }
 
 class MenuProps = UiProps with MenuPropsMixin, ConnectPropsMixin;
@@ -424,6 +426,15 @@ designs that have overlapping non-parallel helices.'''
         ..onChange = ((_) => props.dispatch(actions.ShowHelixCirclesMainViewSet(
             show_helix_circles_main_view: !props.show_helix_circles_main_view)))
         ..key = 'show-helix-circles-main-view')(),
+        (MenuBoolean()
+        ..value = props.show_grid_coordinates_side_view
+        ..display = 'Show grid coordinates in side view'
+        ..tooltip = '''\
+Shows grid coordinates in the side view under the helix index.'''
+        ..name = 'show-grid-coordinates-side-view'
+        ..onChange = ((_) => props.dispatch(actions.ShowGridCoordinatesSideViewSet(
+            show_grid_coordinates_side_view: !props.show_grid_coordinates_side_view)))
+        ..key = 'show-grid-coordinates-side-view')(),
     ];
   }
 


### PR DESCRIPTION
Adds menu option under view named 'Show grid coordinates in side view' to display grid coordinates in smaller font under helix indexes.