### PR TITLE
add option to save/not save DNADesign in localStorage on every edit; closes 348

### DIFF
--- a/lib/src/actions/actions.dart
+++ b/lib/src/actions/actions.dart
@@ -2069,17 +2069,17 @@ abstract class ShowGridCoordinatesSideViewSet
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // add option to not save DNADesign in localStorage on every edit
 
-abstract class SaveDNAInLocalStorageSet
+abstract class SaveDNADesignInLocalStorageSet
     with BuiltJsonSerializable
-    implements AppUIStateStorableAction, Built<SaveDNAInLocalStorageSet, SaveDNAInLocalStorageSetBuilder> {
-  bool get save_dna_in_local_storage;
+    implements AppUIStateStorableAction, Built<SaveDNADesignInLocalStorageSet, SaveDNADesignInLocalStorageSetBuilder> {
+  bool get save_dna_design_in_local_storage;
 
   /************************ begin BuiltValue boilerplate ************************/
-  factory SaveDNAInLocalStorageSet({bool save_dna_in_local_storage}) = _$SaveDNAInLocalStorageSet._;
+  factory SaveDNADesignInLocalStorageSet({bool save_dna_design_in_local_storage}) = _$SaveDNADesignInLocalStorageSet._;
 
-  SaveDNAInLocalStorageSet._();
+  SaveDNADesignInLocalStorageSet._();
 
-  static Serializer<SaveDNAInLocalStorageSet> get serializer => _$saveDNAInLocalStorageSetSerializer;
+  static Serializer<SaveDNADesignInLocalStorageSet> get serializer => _$saveDNADesignInLocalStorageSetSerializer;
 }
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // load dna sequence png

--- a/lib/src/actions/actions.dart
+++ b/lib/src/actions/actions.dart
@@ -2067,6 +2067,21 @@ abstract class ShowGridCoordinatesSideViewSet
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// add option to not save DNADesign in localStorage on every edit
+
+abstract class SaveDNAInLocalStorageSet
+    with BuiltJsonSerializable
+    implements AppUIStateStorableAction, Built<SaveDNAInLocalStorageSet, SaveDNAInLocalStorageSetBuilder> {
+  bool get save_dna_in_local_storage;
+
+  /************************ begin BuiltValue boilerplate ************************/
+  factory SaveDNAInLocalStorageSet({bool save_dna_in_local_storage}) = _$SaveDNAInLocalStorageSet._;
+
+  SaveDNAInLocalStorageSet._();
+
+  static Serializer<SaveDNAInLocalStorageSet> get serializer => _$saveDNAInLocalStorageSetSerializer;
+}
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // load dna sequence png
 
 abstract class LoadDnaSequenceImageUri

--- a/lib/src/middleware/local_storage.dart
+++ b/lib/src/middleware/local_storage.dart
@@ -32,8 +32,7 @@ const String _LOCAL_STORAGE_PREFIX = "scadnano:";
 save(AppState state, Storable storable) {
   String storable_key = _LOCAL_STORAGE_PREFIX + storable.name;
   String value_string;
-
-  if (storable == Storable.dna_design) {
+  if ((storable == Storable.dna_design) && (state.ui_state.save_dna_in_local_storage)) {
     var dna_design = state.dna_design;
     value_string = json_encode(dna_design);
   } else if (storable == Storable.app_ui_state_storables) {
@@ -42,8 +41,8 @@ save(AppState state, Storable storable) {
 
   if (value_string != null)
     window.localStorage[storable_key] = value_string;
-  else
-    window.localStorage.remove(storable_key);
+  //else
+    //window.localStorage.remove(storable_key);
 }
 
 String side_pane_width() {

--- a/lib/src/middleware/local_storage.dart
+++ b/lib/src/middleware/local_storage.dart
@@ -32,7 +32,7 @@ const String _LOCAL_STORAGE_PREFIX = "scadnano:";
 save(AppState state, Storable storable) {
   String storable_key = _LOCAL_STORAGE_PREFIX + storable.name;
   String value_string;
-  if ((storable == Storable.dna_design) && (state.ui_state.save_dna_in_local_storage)) {
+  if ((storable == Storable.dna_design) && (state.ui_state.save_dna_design_in_local_storage)) {
     var dna_design = state.dna_design;
     value_string = json_encode(dna_design);
   } else if (storable == Storable.app_ui_state_storables) {
@@ -41,8 +41,6 @@ save(AppState state, Storable storable) {
 
   if (value_string != null)
     window.localStorage[storable_key] = value_string;
-  //else
-    //window.localStorage.remove(storable_key);
 }
 
 String side_pane_width() {

--- a/lib/src/reducers/app_ui_state_reducer.dart
+++ b/lib/src/reducers/app_ui_state_reducer.dart
@@ -113,6 +113,9 @@ bool show_helix_circles_main_view_reducer(bool _, actions.ShowHelixCirclesMainVi
 bool show_grid_coordinates_side_view_reducer(bool _, actions.ShowGridCoordinatesSideViewSet action) =>
     action.show_grid_coordinates_side_view;
 
+bool save_dna_in_local_storage_reducer(bool _, actions.SaveDNAInLocalStorageSet action) =>
+    action.save_dna_in_local_storage;
+
 bool display_base_offsets_of_major_ticks_reducer(bool _, actions.DisplayMajorTicksOffsetsSet action) =>
     action.show;
 
@@ -206,6 +209,9 @@ AppUIStateStorable app_ui_state_storable_reducer(AppUIStateStorable storables, a
       ..show_grid_coordinates_side_view =
           TypedReducer<bool, actions.ShowGridCoordinatesSideViewSet>(show_grid_coordinates_side_view_reducer)(
               storables.show_grid_coordinates_side_view, action)
+      ..save_dna_in_local_storage =
+          TypedReducer<bool, actions.SaveDNAInLocalStorageSet>(save_dna_in_local_storage_reducer)(
+              storables.save_dna_in_local_storage, action)
       ..strand_paste_keep_color =
           TypedReducer<bool, actions.StrandPasteKeepColorSet>(strand_paste_keep_color_reducer)(storables.strand_paste_keep_color, action)
       ..autofit = TypedReducer<bool, actions.AutofitSet>(center_on_load_reducer)(storables.autofit, action)

--- a/lib/src/reducers/app_ui_state_reducer.dart
+++ b/lib/src/reducers/app_ui_state_reducer.dart
@@ -113,8 +113,8 @@ bool show_helix_circles_main_view_reducer(bool _, actions.ShowHelixCirclesMainVi
 bool show_grid_coordinates_side_view_reducer(bool _, actions.ShowGridCoordinatesSideViewSet action) =>
     action.show_grid_coordinates_side_view;
 
-bool save_dna_in_local_storage_reducer(bool _, actions.SaveDNAInLocalStorageSet action) =>
-    action.save_dna_in_local_storage;
+bool save_dna_design_in_local_storage_reducer(bool _, actions.SaveDNADesignInLocalStorageSet action) =>
+    action.save_dna_design_in_local_storage;
 
 bool display_base_offsets_of_major_ticks_reducer(bool _, actions.DisplayMajorTicksOffsetsSet action) =>
     action.show;
@@ -209,9 +209,9 @@ AppUIStateStorable app_ui_state_storable_reducer(AppUIStateStorable storables, a
       ..show_grid_coordinates_side_view =
           TypedReducer<bool, actions.ShowGridCoordinatesSideViewSet>(show_grid_coordinates_side_view_reducer)(
               storables.show_grid_coordinates_side_view, action)
-      ..save_dna_in_local_storage =
-          TypedReducer<bool, actions.SaveDNAInLocalStorageSet>(save_dna_in_local_storage_reducer)(
-              storables.save_dna_in_local_storage, action)
+      ..save_dna_design_in_local_storage =
+          TypedReducer<bool, actions.SaveDNADesignInLocalStorageSet>(save_dna_design_in_local_storage_reducer)(
+              storables.save_dna_design_in_local_storage, action)
       ..strand_paste_keep_color =
           TypedReducer<bool, actions.StrandPasteKeepColorSet>(strand_paste_keep_color_reducer)(storables.strand_paste_keep_color, action)
       ..autofit = TypedReducer<bool, actions.AutofitSet>(center_on_load_reducer)(storables.autofit, action)

--- a/lib/src/serializers.dart
+++ b/lib/src/serializers.dart
@@ -41,6 +41,7 @@ import 'state/crossover.dart';
 part 'serializers.g.dart';
 
 @SerializersFor([
+  SaveDNAInLocalStorageSet,
   ShowGridCoordinatesSideViewSet,
   ShowHelixCirclesMainViewSet,
   SelectModeToggle,

--- a/lib/src/serializers.dart
+++ b/lib/src/serializers.dart
@@ -41,7 +41,7 @@ import 'state/crossover.dart';
 part 'serializers.g.dart';
 
 @SerializersFor([
-  SaveDNAInLocalStorageSet,
+  SaveDNADesignInLocalStorageSet,
   ShowGridCoordinatesSideViewSet,
   ShowHelixCirclesMainViewSet,
   SelectModeToggle,

--- a/lib/src/state/app_ui_state.dart
+++ b/lib/src/state/app_ui_state.dart
@@ -79,7 +79,7 @@ abstract class AppUIStateStorable
 
   bool get show_grid_coordinates_side_view;
 
-  bool get save_dna_in_local_storage;
+  bool get save_dna_design_in_local_storage;
 
   static void _initializeBuilder(AppUIStateStorableBuilder b) {
     // This ensures that even if these keys are not in localStorage (e.g., due to upgrading),
@@ -107,7 +107,7 @@ abstract class AppUIStateStorable
     b.warn_on_exit_if_unsaved = true;
     b.show_helix_circles_main_view = true;
     b.show_grid_coordinates_side_view = false;
-    b.save_dna_in_local_storage = true;
+    b.save_dna_design_in_local_storage = true;
   }
 
   /************************ begin BuiltValue boilerplate ************************/
@@ -233,7 +233,7 @@ abstract class AppUIState with BuiltJsonSerializable implements Built<AppUIState
 
   bool get show_grid_coordinates_side_view => storables.show_grid_coordinates_side_view;
 
-  bool get save_dna_in_local_storage => storables.save_dna_in_local_storage;
+  bool get save_dna_design_in_local_storage => storables.save_dna_design_in_local_storage;
 
   static void _initializeBuilder(AppUIStateBuilder b) {
     b.mouseover_datas.replace([]);

--- a/lib/src/state/app_ui_state.dart
+++ b/lib/src/state/app_ui_state.dart
@@ -79,6 +79,8 @@ abstract class AppUIStateStorable
 
   bool get show_grid_coordinates_side_view;
 
+  bool get save_dna_in_local_storage;
+
   static void _initializeBuilder(AppUIStateStorableBuilder b) {
     // This ensures that even if these keys are not in localStorage (e.g., due to upgrading),
     // then they will be populated with a default value instead of raising an exception.
@@ -105,6 +107,7 @@ abstract class AppUIStateStorable
     b.warn_on_exit_if_unsaved = true;
     b.show_helix_circles_main_view = true;
     b.show_grid_coordinates_side_view = false;
+    b.save_dna_in_local_storage = true;
   }
 
   /************************ begin BuiltValue boilerplate ************************/
@@ -229,6 +232,8 @@ abstract class AppUIState with BuiltJsonSerializable implements Built<AppUIState
   bool get show_helix_circles_main_view => storables.show_helix_circles_main_view;
 
   bool get show_grid_coordinates_side_view => storables.show_grid_coordinates_side_view;
+
+  bool get save_dna_in_local_storage => storables.save_dna_in_local_storage;
 
   static void _initializeBuilder(AppUIStateBuilder b) {
     b.mouseover_datas.replace([]);

--- a/lib/src/view/menu.dart
+++ b/lib/src/view/menu.dart
@@ -57,7 +57,7 @@ UiFactory<MenuProps> ConnectedMenu = connect<AppState, MenuProps>(
     ..show_helix_circles_main_view = state.ui_state.show_helix_circles_main_view
     ..warn_on_exit_if_unsaved = state.ui_state.warn_on_exit_if_unsaved
     ..show_grid_coordinates_side_view = state.ui_state.show_grid_coordinates_side_view
-    ..save_dna_in_local_storage = state.ui_state.save_dna_in_local_storage),
+    ..save_dna_design_in_local_storage = state.ui_state.save_dna_design_in_local_storage),
   // Used for component test.
   forwardRef: true,
 )(Menu);
@@ -89,7 +89,7 @@ mixin MenuPropsMixin on UiProps {
   bool warn_on_exit_if_unsaved;
   bool show_helix_circles_main_view;
   bool show_grid_coordinates_side_view;
-  bool save_dna_in_local_storage;
+  bool save_dna_design_in_local_storage;
 }
 
 class MenuProps = UiProps with MenuPropsMixin, ConnectPropsMixin;
@@ -184,14 +184,14 @@ really want to exit without saving.'''
         ..display = 'Export codenano')(),
       DropdownDivider({}),
       (MenuBoolean()
-        ..value = props.save_dna_in_local_storage
-        ..display = 'Save DNA Design in localStorage'
+        ..value = props.save_dna_design_in_local_storage
+        ..display = 'Save Design in localStorage'
         ..tooltip = '''\
-Saves DNADesign in localStorage on every edit. Disabling this minimizes the time needed to render large strands.'''
-        ..name = 'save-dna-in-local-storage'
-        ..onChange = ((_) => props.dispatch(actions.SaveDNAInLocalStorageSet(
-            save_dna_in_local_storage: !props.save_dna_in_local_storage)))
-        ..key = 'save-dna-in-local-storage')(),
+Saves designs in localStorage on every edit. Disabling this minimizes the time needed to render large designs.'''
+        ..name = 'save-dna-design-in-local-storage'
+        ..onChange = ((_) => props.dispatch(actions.SaveDNADesignInLocalStorageSet(
+            save_dna_design_in_local_storage: !props.save_dna_design_in_local_storage)))
+        ..key = 'save-dna-design-in-local-storage')(),
     );
   }
 

--- a/lib/src/view/menu.dart
+++ b/lib/src/view/menu.dart
@@ -56,7 +56,8 @@ UiFactory<MenuProps> ConnectedMenu = connect<AppState, MenuProps>(
     ..invert_y_axis = state.ui_state.invert_y_axis
     ..show_helix_circles_main_view = state.ui_state.show_helix_circles_main_view
     ..warn_on_exit_if_unsaved = state.ui_state.warn_on_exit_if_unsaved
-    ..show_grid_coordinates_side_view = state.ui_state.show_grid_coordinates_side_view),
+    ..show_grid_coordinates_side_view = state.ui_state.show_grid_coordinates_side_view
+    ..save_dna_in_local_storage = state.ui_state.save_dna_in_local_storage),
   // Used for component test.
   forwardRef: true,
 )(Menu);
@@ -88,6 +89,7 @@ mixin MenuPropsMixin on UiProps {
   bool warn_on_exit_if_unsaved;
   bool show_helix_circles_main_view;
   bool show_grid_coordinates_side_view;
+  bool save_dna_in_local_storage;
 }
 
 class MenuProps = UiProps with MenuPropsMixin, ConnectPropsMixin;
@@ -180,6 +182,16 @@ really want to exit without saving.'''
       (MenuDropdownItem()
         ..on_click = ((_) => props.dispatch(actions.ExportCodenanoFile()))
         ..display = 'Export codenano')(),
+      DropdownDivider({}),
+      (MenuBoolean()
+        ..value = props.save_dna_in_local_storage
+        ..display = 'Save DNA Design in localStorage'
+        ..tooltip = '''\
+Saves DNADesign in localStorage on every edit. Disabling this minimizes the time needed to render large strands.'''
+        ..name = 'save-dna-in-local-storage'
+        ..onChange = ((_) => props.dispatch(actions.SaveDNAInLocalStorageSet(
+            save_dna_in_local_storage: !props.save_dna_in_local_storage)))
+        ..key = 'save-dna-in-local-storage')(),
     );
   }
 


### PR DESCRIPTION
Adding feature under 'Files' in menu that allows users to enable or disable saving DNA designs into local storage.