### PR TITLE
make default max_offset on every helix equal to the max end of domain on any helix; closes #351

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,3 +1,3 @@
-pub.bat run build_runner clean
+pub run build_runner clean
 bash remove_g.sh
 #rm -rf .dart_tool/build/

--- a/lib/src/middleware/.gitignore
+++ b/lib/src/middleware/.gitignore
@@ -1,0 +1,2 @@
+*.g.dart
+*.g 2.dart

--- a/lib/src/state/.gitignore
+++ b/lib/src/state/.gitignore
@@ -1,1 +1,2 @@
 *.g.dart
+*.g 2.dart

--- a/lib/src/state/dna_design.dart
+++ b/lib/src/state/dna_design.dart
@@ -552,24 +552,8 @@ abstract class DNADesign with UnusedFields implements Built<DNADesign, DNADesign
   }
 
   bool has_nondefault_max_offset(Helix helix) {
-    var ends = domains_on_helix(helix.idx).map((ss) => ss.end);
-    int max_end = 0;
-    int greatest_end_val = 0;
-    for (var strand in strands){
-          for(var domain in strand.domains()){
-            if((domain.end > greatest_end_val)){
-              greatest_end_val = domain.end;
-            }
-          }  
-        }
-    if(ends.isEmpty){
-      max_end = constants.default_max_offset;
-    }else if(helix.max_offset == greatest_end_val){
-      max_end = greatest_end_val;
-    }else{
-      max_end = ends.reduce(max);
-    }
-    return helix.max_offset != max_end;
+    int default_max_end = calculate_default_max_offset(strands);
+    return helix.max_offset != default_max_end;
   }
 
   bool has_nondefault_min_offset(Helix helix) {
@@ -1284,25 +1268,7 @@ _set_helices_min_max_offsets(List<HelixBuilder> helix_builders, Iterable<Strand>
     HelixBuilder helix_builder = helix_builders[idx];
 
     if (helix_builder.max_offset == null) {
-      var substrands = helix_idx_to_substrands[helix_builder.idx];
-      var greatest_max_offset = 0;
-      if(substrands.isEmpty){
-        greatest_max_offset = constants.default_max_offset;
-      }
-      else{
-        for (var strand in strands) {
-          for (var domain in strand.domains()){
-            if(domain.end > greatest_max_offset){
-              greatest_max_offset = domain.end;
-            }
-          }
-        }
-      }
-      var max_offset = greatest_max_offset;
-      for (var substrand in substrands) {
-        max_offset = max(max_offset, substrand.end);
-      }
-      helix_builder.max_offset = max_offset;
+      helix_builder.max_offset = calculate_default_max_offset(strands);
     }
 
     if (helix_builder.min_offset == null) {
@@ -1322,6 +1288,24 @@ _set_helices_min_max_offsets(List<HelixBuilder> helix_builders, Iterable<Strand>
       }
     }
   }
+}
+
+int calculate_default_max_offset(Iterable<Strand> strands) {
+  int greatest_max_offset;
+  if(strands.isEmpty){
+    greatest_max_offset = constants.default_max_offset;
+  }
+  else{
+    greatest_max_offset = strands.first.first_domain().end;
+    for (var strand in strands) {
+      for (var domain in strand.domains()){
+        if(domain.end > greatest_max_offset){
+          greatest_max_offset = domain.end;
+        }
+      }
+    }
+  }
+  return greatest_max_offset;
 }
 
 class Mismatch {

--- a/lib/src/state/dna_design.dart
+++ b/lib/src/state/dna_design.dart
@@ -553,11 +553,20 @@ abstract class DNADesign with UnusedFields implements Built<DNADesign, DNADesign
 
   bool has_nondefault_max_offset(Helix helix) {
     var ends = domains_on_helix(helix.idx).map((ss) => ss.end);
+    var starts = domains_on_helix(helix.idx).map((ss) => ss.start);
     int max_end = 0;
+    int greatest_end_val = 0;
+    for (var strand in strands){
+          for(var substrand in strand.substrands){
+            if((substrand.dna_length() + starts.first) > greatest_end_val){
+              greatest_end_val = substrand.dna_length() + starts.first;
+            }
+          }  
+        }
     if(ends.isEmpty){
       max_end = constants.default_max_offset;
-    }else if(helix.max_offset == constants.default_max_offset){
-      max_end = helix.max_offset;
+    }else if(helix.max_offset == greatest_end_val){
+      max_end = greatest_end_val;
     }else{
       max_end = ends.reduce(max);
     }

--- a/lib/src/state/dna_design.dart
+++ b/lib/src/state/dna_design.dart
@@ -553,7 +553,14 @@ abstract class DNADesign with UnusedFields implements Built<DNADesign, DNADesign
 
   bool has_nondefault_max_offset(Helix helix) {
     var ends = domains_on_helix(helix.idx).map((ss) => ss.end);
-    int max_end = ends.isEmpty ? constants.default_max_offset : ends.reduce(max);
+    int max_end = 0;
+    if(ends.isEmpty){
+      max_end = constants.default_max_offset;
+    }else if(helix.max_offset == constants.default_max_offset){
+      max_end = helix.max_offset;
+    }else{
+      max_end = ends.reduce(max);
+    }
     return helix.max_offset != max_end;
   }
 

--- a/lib/src/state/dna_design.dart
+++ b/lib/src/state/dna_design.dart
@@ -553,13 +553,12 @@ abstract class DNADesign with UnusedFields implements Built<DNADesign, DNADesign
 
   bool has_nondefault_max_offset(Helix helix) {
     var ends = domains_on_helix(helix.idx).map((ss) => ss.end);
-    var starts = domains_on_helix(helix.idx).map((ss) => ss.start);
     int max_end = 0;
     int greatest_end_val = 0;
     for (var strand in strands){
-          for(var substrand in strand.substrands){
-            if((substrand.dna_length() + starts.first) > greatest_end_val){
-              greatest_end_val = substrand.dna_length() + starts.first;
+          for(var domain in strand.domains()){
+            if((domain.end > greatest_end_val)){
+              greatest_end_val = domain.end;
             }
           }  
         }
@@ -1289,13 +1288,14 @@ _set_helices_min_max_offsets(List<HelixBuilder> helix_builders, Iterable<Strand>
       var greatest_max_offset = 0;
       if(substrands.isEmpty){
         greatest_max_offset = constants.default_max_offset;
-      }else{
-        for (var strand in strands){
-          for(var substrand in strand.substrands){
-            if((substrand.dna_length() + substrands.first.start) > greatest_max_offset){
-              greatest_max_offset = substrand.dna_length() + substrands.first.start;
+      }
+      else{
+        for (var strand in strands) {
+          for (var domain in strand.domains()){
+            if(domain.end > greatest_max_offset){
+              greatest_max_offset = domain.end;
             }
-          }  
+          }
         }
       }
       var max_offset = greatest_max_offset;

--- a/lib/src/state/dna_design.dart
+++ b/lib/src/state/dna_design.dart
@@ -1270,7 +1270,19 @@ _set_helices_min_max_offsets(List<HelixBuilder> helix_builders, Iterable<Strand>
 
     if (helix_builder.max_offset == null) {
       var substrands = helix_idx_to_substrands[helix_builder.idx];
-      var max_offset = substrands.isEmpty ? constants.default_max_offset : substrands.first.end;
+      var greatest_max_offset = 0;
+      if(substrands.isEmpty){
+        greatest_max_offset = constants.default_max_offset;
+      }else{
+        for (var strand in strands){
+          for(var substrand in strand.substrands){
+            if((substrand.dna_length() + substrands.first.start) > greatest_max_offset){
+              greatest_max_offset = substrand.dna_length() + substrands.first.start;
+            }
+          }  
+        }
+      }
+      var max_offset = greatest_max_offset;
       for (var substrand in substrands) {
         max_offset = max(max_offset, substrand.end);
       }

--- a/test/reducer_test.dart
+++ b/test/reducer_test.dart
@@ -4262,6 +4262,39 @@ main() {
     expect_dna_design_equal(state.dna_design, expected_design);
   });
 
+  String design_3helicies_strands_on_1and2_json = r'''
+ {
+  "version": "''' +
+      constants.CURRENT_VERSION +
+      r'''", "grid": "square", "helices": [ 
+    {"grid_position": [0, 0]},
+    {"grid_position": [0, 1]},
+    {"grid_position": [0, 2]}
+  ],
+  "strands": [
+    {
+      "domains": [
+        {"helix": 1, "forward": false, "start": 0, "end": 10}
+      ]
+    },
+    {
+      "domains": [
+        {"helix": 2, "forward": true, "start": 0, "end": 20}
+      ]
+    }
+  ]
+ }
+  ''';
+  DNADesign design_3helicies_strands_on_1and2 =
+      DNADesign.from_json(jsonDecode(design_3helicies_strands_on_1and2_json));
+  test('default_helix_max_offsets', () {
+    for (var helix = 0; helix < 3; helix++) {
+      int expected_max_offset_helix = 20;
+      int actual_max_offset_helix = design_3helicies_strands_on_1and2.helices[helix].max_offset;
+      expect(actual_max_offset_helix, expected_max_offset_helix);
+    }
+  });
+
   group('Loopout length change test:', () {
     test('LoopoutLengthChange', () {
       // simple_loopout_design


### PR DESCRIPTION


If the max_offsets of helices are not specified, make the max_offset the same for every helix (by setting it equal to the max end of domain).