### PR TITLE
unselect strands when switching out of select mode; closes #389

### DIFF
--- a/lib/src/view/edit_mode.dart
+++ b/lib/src/view/edit_mode.dart
@@ -32,14 +32,12 @@ class EditModeComponent extends UiComponent2<EditModeProps> with RedrawCounterMi
       ...[for (var choice in EditModeChoice.values) this._button_for_choice(choice)],
     ]);
   }
-  static button_response(EditModeChoice mode){
-    app.dispatch(actions.EditModeToggle(mode));
-    app.dispatch(actions.SelectionsClear());
-  }
-
   ReactElement _button_for_choice(EditModeChoice mode) {
     return (Dom.button()
-      ..onClick = ((_) => button_response(mode))
+      ..onClick = (_) {
+        app.dispatch(actions.EditModeToggle(mode));
+        app.dispatch(actions.SelectionsClear());
+      }
       ..className = 'mode-button ' +
           (props.modes.contains(mode) ? 'edit-mode-button-selected' : 'edit-mode-button-unselected')
       // TODO(benlee12): Find out how to only added this id for testing and not production if inefficient.

--- a/lib/src/view/edit_mode.dart
+++ b/lib/src/view/edit_mode.dart
@@ -32,10 +32,14 @@ class EditModeComponent extends UiComponent2<EditModeProps> with RedrawCounterMi
       ...[for (var choice in EditModeChoice.values) this._button_for_choice(choice)],
     ]);
   }
+  static button_response(EditModeChoice mode){
+    app.dispatch(actions.EditModeToggle(mode));
+    app.dispatch(actions.SelectionsClear());
+  }
 
   ReactElement _button_for_choice(EditModeChoice mode) {
     return (Dom.button()
-      ..onClick = ((_) => app.dispatch(actions.EditModeToggle(mode)))
+      ..onClick = ((_) => button_response(mode))
       ..className = 'mode-button ' +
           (props.modes.contains(mode) ? 'edit-mode-button-selected' : 'edit-mode-button-unselected')
       // TODO(benlee12): Find out how to only added this id for testing and not production if inefficient.

--- a/test/reducer_test.dart
+++ b/test/reducer_test.dart
@@ -3051,6 +3051,14 @@ main() {
       expect(final_state.ui_state.edit_modes, edit_modes);
     });
   });
+   test('clicking_out_of_select_mode_unselects_strands', () {
+     SelectablesStore edit_mode_store = SelectablesStore().select(two_helices_design.strands[0]);
+     AppState initial_state = app_state_from_dna_design(two_helices_design).rebuild((b) => b
+     ..ui_state.storables.edit_modes.replace([EditModeChoice.select]));
+     initial_state.ui_state.selectables_store.select(two_helices_design.strands[0]);
+     AppState final_state = app_state_reducer(initial_state, EditModeToggle(EditModeChoice.pencil));
+     expect(final_state.ui_state.selectables_store, edit_mode_store.unselect(two_helices_design.strands[0]));
+      });
 
   group('Select modes tests: ', () {
     test('SelectModeToggle_to_toggle_off', () {


### PR DESCRIPTION
Updating state to unselect all items when switching out of select mode. Added test case for future reference as well.