### PR TITLE
Disable redux dev tools for release

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -22,6 +22,14 @@
 targets:
   $default:
     builders:
+      build_web_compilers|entrypoint:
+        # These are globs for the entrypoints you want to compile.
+        options:
+          compiler: dartdevc
+        release_options:
+          compiler: dart2js
+          dart2js_args:
+            - -DSCADNANO_PROD=true
       test_html_builder:
         options:
           templates:

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -37,7 +37,7 @@ import 'actions/actions.dart' as actions;
 // global variable for whole program
 App app = App();
 
-const USE_REDUX_DEV_TOOLS = false;
+const USE_REDUX_DEV_TOOLS = String.fromEnvironment('SCADNANO_PROD') != 'true';
 //const USE_REDUX_DEV_TOOLS = true;
 
 const RUN_TEST_CODE_INSTEAD_OF_APP = false;


### PR DESCRIPTION
Fixes #399 (in terms of disabling redux dev tools) react dev tools will still work