### PR TITLE
Modify CI UT workflow so it only run on PRs

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,6 +1,6 @@
 name: Dart CI
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This allows CI checks to run on PRs made by external users. This should slightly reduce the frequency of CI tests running because not every push will trigger a build.