### PR TITLE
Performance improvement for strand selection

### DIFF
--- a/lib/src/view/design_main_strand.dart
+++ b/lib/src/view/design_main_strand.dart
@@ -54,7 +54,6 @@ mixin DesignMainStrandPropsMixin on UiProps {
   bool selected;
   bool drawing_potential_crossover;
   bool moving_dna_ends;
-  bool currently_moving;
   bool assign_complement_to_bound_strands_default;
   bool warn_on_change_strand_dna_assign_default;
   bool modification_display_connector;
@@ -99,7 +98,6 @@ class DesignMainStrandComponent extends UiComponent2<DesignMainStrandProps>
         ..show_domain_labels = props.show_domain_labels
         ..helices = props.helices
         ..groups = props.groups
-        ..currently_moving = props.currently_moving
         ..selected_ends_in_strand = props.selected_ends_in_strand
         ..selected_crossovers_in_strand = props.selected_crossovers_in_strand
         ..selected_loopouts_in_strand = props.selected_loopouts_in_strand
@@ -157,7 +155,10 @@ class DesignMainStrandComponent extends UiComponent2<DesignMainStrandProps>
       // want, which is that if we are moving a group of strands, and we are in a disallowed position where
       // the pointer itself (so also some strands) are positioned directly over a visible part of a strand,
       // then it would otherwise become selected on mouse up, when really we just want to end the move.
-      if (strand_selectable(props.strand) && !props.currently_moving) {
+      bool currently_moving = app.state.ui_state.strands_move != null ||
+          app.state.ui_state.domains_move != null ||
+          app.state.ui_state.dna_ends_are_moving;
+      if (strand_selectable(props.strand) && !currently_moving) {
         props.strand.handle_selection_mouse_up(event_syn.nativeEvent);
       }
     }

--- a/lib/src/view/design_main_strand_domain.dart
+++ b/lib/src/view/design_main_strand_domain.dart
@@ -36,7 +36,6 @@ mixin DesignMainDomainPropsMixin on UiProps {
   Strand strand;
   String transform;
   List<ContextMenuItem> Function(Strand strand, {Domain domain, Address address}) context_menu_strand;
-  bool currently_moving;
   bool selected;
 
   BuiltMap<int, Helix> helices;
@@ -125,7 +124,10 @@ class DesignMainDomainComponent extends UiComponent2<DesignMainDomainProps>
       // want, which is that if we are moving a group of strands, and we are in a disallowed position where
       // the pointer itself (so also some strands) are positioned directly over a visible part of a strand,
       // then it would otherwise become selected on mouse up, when really we just want to end the move.
-      if (domain_selectable(props.domain) && !props.currently_moving) {
+      bool currently_moving = app.state.ui_state.strands_move != null ||
+          app.state.ui_state.domains_move != null ||
+          app.state.ui_state.dna_ends_are_moving;
+      if (domain_selectable(props.domain) && !currently_moving) {
         props.domain.handle_selection_mouse_up(event_syn.nativeEvent);
       }
     }

--- a/lib/src/view/design_main_strand_paths.dart
+++ b/lib/src/view/design_main_strand_paths.dart
@@ -40,7 +40,6 @@ mixin DesignMainStrandPathsPropsMixin on UiProps {
   BuiltMap<String, HelixGroup> groups;
   Geometry geometry;
 
-  bool currently_moving;
   bool show_domain_labels;
   bool drawing_potential_crossover;
   bool moving_dna_ends;
@@ -97,7 +96,6 @@ class DesignMainStrandPathsComponent extends UiComponent2<DesignMainStrandPathsP
           paths.add((DesignMainDomain()
             ..domain = domain
             ..strand = props.strand
-            ..currently_moving = props.currently_moving
             ..transform = transform_of_helix(domain.helix)
             ..context_menu_strand = props.context_menu_strand
             ..color = strand.color

--- a/lib/src/view/design_main_strands.dart
+++ b/lib/src/view/design_main_strands.dart
@@ -22,9 +22,6 @@ UiFactory<DesignMainStrandsProps> ConnectedDesignMainStrands =
     ..groups = state.design.groups
     ..side_selected_helix_idxs = state.ui_state.side_selected_helix_idxs
     ..selectables_store = state.ui_state.selectables_store
-    ..currently_moving = state.ui_state.strands_move != null ||
-        state.ui_state.domains_move != null ||
-        state.ui_state.dna_ends_are_moving
     ..drawing_potential_crossover = state.ui_state.potential_crossover_is_drawing
     ..moving_dna_ends = state.ui_state.dna_ends_are_moving
     ..assign_complement_to_bound_strands_default = state.ui_state.assign_complement_to_bound_strands_default
@@ -54,7 +51,6 @@ mixin DesignMainStrandsProps on UiProps {
   num domain_label_font_size;
   bool drawing_potential_crossover;
   bool moving_dna_ends;
-  bool currently_moving;
   bool assign_complement_to_bound_strands_default;
   bool warn_on_change_strand_dna_assign_default;
   bool only_display_selected_helices;
@@ -91,7 +87,6 @@ class DesignMainStrandsComponent extends UiComponent2<DesignMainStrandsProps> wi
         ..selected_crossovers_in_strand = selected_crossovers_in_strand
         ..selected_loopouts_in_strand = selected_loopouts_in_strand
         ..selected_domains_in_strand = selected_domains_in_strand
-        ..currently_moving = props.currently_moving
         ..drawing_potential_crossover = props.drawing_potential_crossover
         ..moving_dna_ends = props.moving_dna_ends
         ..assign_complement_to_bound_strands_default = props.assign_complement_to_bound_strands_default


### PR DESCRIPTION
Remove passing in app's "currently moving" state via props and instead
directly access the global model from the view.

This makes it so that only the strand that gets selected is rerendered.