### PR TITLE
Fixes #490; store old versions of scadnano at version-specific URLs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,6 +40,15 @@ jobs:
       - name: Build into gh-pages repo
         run: PATH="$PATH:/usr/lib/dart/bin" pub global run webdev build -o web:gh-pages-repo
       
+      - name: Retrieve version
+        run: export VERSION=$(cat lib/src/constants.dart | grep  "const String CURRENT_VERSION = .*" | grep -oP "\d+\.\d+\.\d+")
+      - name: Build into gh-pages-repo/VERSION
+        run: |
+         if [ "$VERSION" != "" ]; then
+            PATH="$PATH:/usr/lib/dart/bin" pub global run webdev build -o web:gh-pages-repo/$VERSION
+         else
+            echo "::warning deploying VERSION skipped because VERSION number could not be found"
+         fi
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -5,6 +5,7 @@ import 'package:platform_detect/platform_detect.dart';
 
 import 'state/grid.dart';
 
+// WARNING: Do not modify line below, except for the version string.
 const String CURRENT_VERSION = "0.13.0";
 const String INITIAL_VERSION = "0.1.0";
 


### PR DESCRIPTION
Tested in Fork: https://unhumbleben.github.io/scadnano/v0.11.3/
Here is example of when version number cannot be parsed: https://github.com/UnHumbleBen/scadnano/actions/runs/358816601
Root deployment still runs, but version url gets skipped and a warning message is fired so that we know we need to fix the version string.
