### PR TITLE
Fixes #571; fix workflow/links for older versions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build into gh-pages-repo/VERSION
         run: |
          if [ "$VERSION" != "" ]; then
-            PATH="$PATH:/usr/lib/dart/bin" pub global run webdev build -o web:gh-pages-repo/$VERSION
+            PATH="$PATH:/usr/lib/dart/bin" pub global run webdev build -o web:gh-pages-repo/v$VERSION
          else
             echo "::warning deploying VERSION skipped because VERSION number could not be found"
          fi

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -15,7 +15,6 @@ const String INITIAL_VERSION = "0.1.0";
 final scadnano_older_versions_to_link =[
   "0.15.1",
   "0.15.0",
-  "0.14.1",
   "0.14.0",
   "0.13.4",
   "0.13.3",

--- a/lib/src/view/menu.dart
+++ b/lib/src/view/menu.dart
@@ -732,11 +732,11 @@ In a large design, this can slow down the performance, so uncheck it when not in
     for (var version in constants.scadnano_versions_to_link) {
       var version_dropdown_item = DropdownItem(
         {
-          'href': 'https://scadnano.org/v${version}',
+          'href': 'https://scadnano.org/v${version}/index.html',
           'target': '_blank',
           'key': version,
           'title': '''\
-    Version v${version} of scadnano, located at https://scadnano.org/v${version}.'''
+    Version v${version} of scadnano, located at https://scadnano.org/v${version}/index.html.'''
         },
         'v${version}' + (first ? ' (current version)' : ''),
       );


### PR DESCRIPTION
Tested Workflow: https://unhumbleben.github.io/scadnano/v0.15.2/

This was deployed via the `github-pages` action. Note that "v" is properly placed in the directory name