### PR TITLE
Fixes #655; side menu not working in scadnano.org/dev

### DIFF
--- a/lib/src/view/edit_and_select_modes.dart
+++ b/lib/src/view/edit_and_select_modes.dart
@@ -54,11 +54,9 @@ class EditAndSelectModesComponent extends UiComponent2<EditAndSelectModesProps> 
           ..className = FIXED_VERTICAL_SEPARATOR //FIXED_HORIZONTAL_SEPARATOR
           ..key = 'modes-separator')(),
       if (props.edit_mode_menu_visible)
-        {
-          (EditMode()
-            ..modes = props.edit_modes
-            ..key = 'edit-modes')(),
-        },
+        (EditMode()
+          ..modes = props.edit_modes
+          ..key = 'edit-modes')(),
       (Dom.button()
         ..key = 'edit-mode-toggle-button'
         ..className = 'edit-mode-toggle-button'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Patch side menu component to fix missing side menu issue in scadnano.org/dev

## TL;DR
Bug was caused by the braces in the if clause. Removing the braces fixed the bug.

## Description

Probably the strangest bug I have ever encountered. The cause of the bug: Dart is an ambiguous language. In other words, given the same source, code, there can be two different interpretations of the same source code. For this issue, the problem lies in this snippet of code:

https://github.com/UC-Davis-molecular-computing/scadnano/blob/38ca294d612885d341577e4f6a255313ee6ae9fa/lib/src/view/edit_and_select_modes.dart#L56-L61

There are two ways to interpret this line. The intended interpretation is that this is an if clause equivalent to the same code with the "{" placed the line before (I'm theorizing this is what the dartdevc compiler saw).
```dart
 if (props.edit_mode_menu_visible) { 
     (EditMode() 
       ..modes = props.edit_modes 
       ..key = 'edit-modes')(), 
   }, 
``` 

The second interpretation (I'm theorizing this is what the dart2js compiler saw) is that this is a one line if statement where the body of the if statement is a Dart Set containing the `EditMode` component.

```dart
 if (props.edit_mode_menu_visible) 
    { // this is the left curly brace to mark the start of a Dart Set!
     (EditMode() 
       ..modes = props.edit_modes 
       ..key = 'edit-modes')(), 
    }, // this is the right curly brace to mark the end of a Dart Set!
```

This is what leads to the error message
```
Uncaught Error: Objects are not valid as a React child (found: object with keys {_collection$_length, _collection$_strings, _collection$_nums, _collection$_rest, _collection$_first, _collection$_last, _collection$_modifications, $ti}). If you meant to render a collection of children, use an array instead.
```

Another theory is that both dartdevc and dart2js both interpreted the line as a set, but dartdevc has more laxed type checking and somehow inferred to use the content of the set instead (the `EditMode`) component and just ignore the set part.

## Related Issue
#655 

## How Has This Been Tested?
Ran in release mode using `webdev serve --release` compiled with Dart 2.9 and verified that side menu is displayed with no errors in the console.

