### PR TITLE
Fixes #699; Fix release note workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Build & test"
         run: |
           echo "done!"
-      - uses: "marvinpinto/action-automatic-releases@v1.1.0"
+      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
         with:


### PR DESCRIPTION
## Description
Fix release note workflow by upgrading marvinpinto/action-automatic-releases from v1.1.0 to v1.2.1

## Related Issue
#699 

## How Has This Been Tested?

Ran the updated job on my fork and verified that the [job succeeded](https://github.com/UnHumbleBen/scadnano/runs/4542338732?check_suite_focus=true) and [the release note was generated](https://github.com/UnHumbleBen/scadnano/releases/tag/latest).

## Note on Merging to Main:

Verify that all other workflows have been disabled to avoid rerunning then unnecessarily. Only the "release" workflow should be enabled.
