### PR TITLE
Fixes #699; Fix release note workflow and run workflow for v0.17.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Build & test"
         run: |
           echo "done!"
-      - uses: "marvinpinto/action-automatic-releases@v1.1.0"
+      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
         with:

--- a/lib/src/view/helix_group_moving.dart
+++ b/lib/src/view/helix_group_moving.dart
@@ -54,6 +54,7 @@ class HelixGroupMovingComponent extends UiComponent2<HelixGroupMovingProps> with
           !only_display_selected_helices) {
         children.add((DesignMainHelix()
           ..helix = helix
+          ..selected = side_selected_helix_idxs.contains(helix.idx)
           ..show_dna = false
           ..show_helix_circles = props.show_helix_circles
           ..helix_change_apply_to_all = false


### PR DESCRIPTION
## Description
Fix release note workflow by upgrading marvinpinto/action-automatic-releases from v1.1.0 to v1.2.1

## Related Issue
#699 

## How Has This Been Tested?

Ran the updated job on my fork and verified that the [job succeeded](https://github.com/UnHumbleBen/scadnano/runs/4542338732?check_suite_focus=true) and [the release note was generated](https://github.com/UnHumbleBen/scadnano/releases/tag/latest).

## Note on Merging to Main:

Verify that all other workflows have been disabled to avoid rerunning then unnecessarily. Only the "release" workflow should be enabled.
