### PR TITLE
Fixes #697; fix JSON encoding warning on startup

### DIFF
--- a/lib/src/actions/actions.dart
+++ b/lib/src/actions/actions.dart
@@ -8,6 +8,7 @@ import 'package:built_value/serializer.dart';
 import 'package:color/color.dart';
 import 'package:js/js.dart';
 import 'package:built_collection/built_collection.dart';
+import 'package:scadnano/src/dna_file_type.dart';
 import 'package:scadnano/src/state/domains_move.dart';
 import 'package:scadnano/src/state/export_dna_format_strand_order.dart';
 import 'package:scadnano/src/state/geometry.dart';

--- a/lib/src/dna_file_type.dart
+++ b/lib/src/dna_file_type.dart
@@ -1,0 +1,23 @@
+import 'package:built_value/built_value.dart';
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/serializer.dart';
+
+part 'dna_file_type.g.dart';
+
+class DNAFileType extends EnumClass {
+  const DNAFileType._(String name) : super(name);
+
+  @memoized
+  int get hashCode;
+
+  static Serializer<DNAFileType> get serializer => _$dNAFileTypeSerializer;
+
+  /******************** end BuiltValue boilerplate *********************/
+
+  static const DNAFileType scadnano_file = _$scadnano_file;
+  static const DNAFileType cadnano_file = _$cadnano_file;
+
+  static BuiltSet<DNAFileType> get values => _$values;
+  static DNAFileType valueOf(String name) => _$valueOf(name);
+}
+

--- a/lib/src/reducers/load_dna_file_reducer.dart
+++ b/lib/src/reducers/load_dna_file_reducer.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:built_collection/built_collection.dart';
+import 'package:scadnano/src/dna_file_type.dart';
 import '../state/selectable.dart';
 
 import '../state/design.dart';
@@ -19,10 +20,10 @@ AppState load_dna_file_reducer(AppState state, actions.LoadDNAFile action) {
 
   try {
     switch (action.dna_file_type) {
-      case util.DNAFileType.scadnano_file:
+      case DNAFileType.scadnano_file:
         design_new = Design.from_json_str(action.content, state.ui_state.invert_xy);
         break;
-      case util.DNAFileType.cadnano_file:
+      case DNAFileType.cadnano_file:
         design_new = Design.from_cadnano_v2_json_str(action.content, state.ui_state.invert_xy);
         break;
     }

--- a/lib/src/serializers.dart
+++ b/lib/src/serializers.dart
@@ -5,6 +5,7 @@ import 'package:built_value/serializer.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/standard_json_plugin.dart';
 import 'package:color/color.dart';
+import 'package:scadnano/src/dna_file_type.dart';
 import 'package:tuple/tuple.dart';
 
 import 'state/domains_move.dart';
@@ -105,6 +106,7 @@ part 'serializers.g.dart';
   SetShowEditor,
   SaveDNAFile,
   LoadDNAFile,
+  DNAFileType,
   ExportCadnanoFile,
   ExportCodenanoFile,
   MouseoverDataClear,

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -1624,5 +1624,3 @@ Map<int, int> invert_helices_view_order(Iterable<int> helices_view_order) {
   }
   return view_order_inverse;
 }
-
-enum DNAFileType { scadnano_file, cadnano_file }

--- a/lib/src/view/menu.dart
+++ b/lib/src/view/menu.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
 import 'package:over_react/over_react.dart';
 import 'package:over_react/over_react_redux.dart';
+import 'package:scadnano/src/dna_file_type.dart';
 import 'package:scadnano/src/json_serializable.dart';
 import 'package:scadnano/src/state/design.dart';
 import 'package:scadnano/src/state/dna_end.dart';
@@ -1167,7 +1168,7 @@ cadnano_file_loaded(FileReader file_reader, String filename) async {
   try {
     var json_cadnano_text = file_reader.result;
     filename = path.setExtension(filename, '.${constants.default_scadnano_file_extension}');
-    app.dispatch(actions.LoadDNAFile(content: json_cadnano_text, filename: filename, dna_file_type: util.DNAFileType.cadnano_file));
+    app.dispatch(actions.LoadDNAFile(content: json_cadnano_text, filename: filename, dna_file_type: DNAFileType.cadnano_file));
   } on Exception catch (e) {
     window.alert('Error importing file: ${e}');
   }


### PR DESCRIPTION
## Description
Replace the DNAFileType `enum` with a DNAFileType `EnumClass`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes #697, which was caused by the OverReactReduxDevToolsMiddleware failing to find a serializer for DNAFileType. Rewriting DNAFileType as a `EnumClass` resolves this issue.

## How Has This Been Tested?
Built locally and verified that the warning message is gone.