### PR TITLE
Fixes #668; fix crash error when deselecting strand while strands from multiple helix groups are selected

### DIFF
--- a/lib/src/reducers/strands_reducer.dart
+++ b/lib/src/reducers/strands_reducer.dart
@@ -217,19 +217,24 @@ Strand move_strand(
     substrands = substrands.reversed.toList();
   }
 
+  bool is_moving = delta_view_order > 0 || delta_offset > 0 || delta_forward;
+
   for (int i = 0; i < substrands.length; i++) {
     Substrand substrand = substrands[i];
     Substrand new_substrand = substrand;
     // Substrands includes Domains and Loopouts,
     // but only Domains need to be processed since only they have helix idx and start/end offsets
     if (substrand is Domain) {
-      if (!original_helices_view_order_inverse.containsKey(substrand.helix)) {
+      if (!original_helices_view_order_inverse.containsKey(substrand.helix) && is_moving) {
         throw AssertionError('original_helices_view_order_inverse = $original_helices_view_order_inverse '
             'does not contain key (helix idx) = ${substrand.helix}');
       }
-      num original_view_order = original_helices_view_order_inverse[substrand.helix];
-      num new_view_order = original_view_order + delta_view_order;
-      int new_helix_idx = current_group.helices_view_order[new_view_order];
+      int new_helix_idx = substrand.helix;
+      if (is_moving) {
+        num original_view_order = original_helices_view_order_inverse[substrand.helix];
+        num new_view_order = original_view_order + delta_view_order;
+        new_helix_idx = current_group.helices_view_order[new_view_order];
+      }
       assert(new_helix_idx != null);
       Domain domain_moved = substrand.rebuild(
         (b) => b

--- a/lib/src/reducers/strands_reducer.dart
+++ b/lib/src/reducers/strands_reducer.dart
@@ -217,7 +217,7 @@ Strand move_strand(
     substrands = substrands.reversed.toList();
   }
 
-  bool is_moving = delta_view_order > 0 || delta_offset > 0 || delta_forward;
+  bool is_moving = delta_view_order != 0 || delta_offset != 0 || delta_forward;
 
   for (int i = 0; i < substrands.length; i++) {
     Substrand substrand = substrands[i];

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -102,6 +102,9 @@ void expect_strands_equal(BuiltList<Strand> actual_strands, BuiltList<Strand> ex
   if (actual_recolored_strands.hashCode != expected_recolored_strands.hashCode) {
     expect(actual_recolored_strands.length, expected_recolored_strands.length);
     for (Strand strand in expected_recolored_strands) {
+      if (!actual_recolored_strands.contains(strand)) {
+        print("strand ${strand} not found in actual_recolored_strands: ${actual_recolored_strands}");
+      }
       expect(actual_recolored_strands.contains(strand), true);
     }
   }


### PR DESCRIPTION
## Description
Change `move_strand` logic so that the current group's view order inverse map is only accessed if the strand is not moving.

## Related Issue
#668

## Motivation and Context
`move_strand` is used for displaying selected strands as well as moving strands. Moving strands requires accessing the current helix group's inverse view order map in order to determine what helix to move the strand. This logic works fine in the case of moving strands, but breaks when displaying selected strands because when selected strands are in different groups, the strands that are not in the current group will not belong to a helix that is contained in the current group's inverse view order map, leading to the error message in the issue linked above. Since the inverse view order map is only needed for the use case when the strand is actually moving, the fix is to first check if the strand is moving before accessing the map.


## How Has This Been Tested?
Reenacted the scenario in #668 and verified that crash error no longer happens.
