### PR TITLE
Closes #686; Don't run unit tests on draft/incomplete PRs

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,9 +1,12 @@
 name: Dart CI
 
-on: [pull_request]
+on:  
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  build:
+  run_unit_tests:
+    if: github.event.pull_request.draft == false
 
     runs-on: ubuntu-18.04
 
@@ -25,3 +28,10 @@ jobs:
       run: PATH="$PATH:/usr/lib/dart/bin" pub get
     - name: Run tests
       run: PATH="$PATH:/usr/lib/dart/bin" pub run build_runner test
+
+  fail_if_pull_request_is_draft:
+    if: github.event.pull_request.draft == true
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Fails in order to indicate that pull request needs to be marked as ready to review and unit tests workflow needs to pass.
+      run: exit 1


### PR DESCRIPTION
## Description
Modify Dart CI so that unit tests only run on PRs ready for review (not a draft). This will give us more control over when unit tests are executed. To prevent accidental merges, the job will fail whenever the PR is in draft. This ensures PR does not pass the checks unless unit tests have actually ran.

This is implemented using this solution: https://github.community/t/dont-run-actions-on-draft-pull-requests/16817/16 and https://github.community/t/dont-run-actions-on-draft-pull-requests/16817/20


## Related Issue
#686 

## Motivation and Context
Currently, unit tests are executed on every change made to a PR. This can be wasteful when a PR is a work in progress and unit tests are not needed anyways. This change will allow us to more judiciously pick when to run unit tests. We can now make PR a draft to disable unit tests. 

## How Has This Been Tested?
Verified workflow in fork:
- [x] Verify that in draft, unit tests are skipped and job fails: https://github.com/UnHumbleBen/scadnano/actions/runs/1730242625
- [x] Verify that in ready to review unit tests are run and job passes: https://github.com/UnHumbleBen/scadnano/actions/runs/1730244907

Verified workflow in this PR:
- [x] Verify that in draft, unit tests are skipped and job fails
- [x] Verify that in ready to review unit tests are run and job passes