### PR TITLE
Fixes #492; Refactor Dart data model: store DNA sequence in domains and loopouts, rather in strand

### DIFF
--- a/lib/src/reducers/change_loopout_length.dart
+++ b/lib/src/reducers/change_loopout_length.dart
@@ -130,6 +130,7 @@ BuiltList<Strand> loopouts_length_change_reducer(
 }
 
 Strand loopout_length_change_reducer(Strand strand, actions.LoopoutLengthChange action) {
+  var old_dna_sequence = strand.dna_sequence;
   int loopout_idx = strand.substrands.indexOf(action.loopout);
   var substrands_builder = strand.substrands.toBuilder();
   if (action.length > 0) {
@@ -141,5 +142,8 @@ Strand loopout_length_change_reducer(Strand strand, actions.LoopoutLengthChange 
     substrands_builder.removeAt(loopout_idx);
   }
   strand = strand.rebuild((s) => s..substrands = substrands_builder);
+  if (old_dna_sequence != null) {
+    strand = strand.set_dna_sequence(old_dna_sequence);
+  }
   return strand;
 }

--- a/lib/src/reducers/nick_ligate_join_by_crossover_reducers.dart
+++ b/lib/src/reducers/nick_ligate_join_by_crossover_reducers.dart
@@ -228,13 +228,8 @@ BuiltList<Strand> nick_reducer(BuiltList<Strand> strands, AppState state, action
 
   if (strand.circular) {
     var substrands = substrands_after + substrands_before;
-    String dna_sequence = null;
-    if (strand.dna_sequence != null) {
-      dna_sequence = dna_before + dna_after;
-    }
     var strand_new = strand.rebuild((b) => b
       ..substrands.replace(substrands)
-      ..dna_sequence = dna_sequence
       ..circular = false);
     strand_new = strand_new.initialize();
 
@@ -649,7 +644,7 @@ Strand join_two_strands_with_substrands(
 
   //TODO: use properties_from_strand_3p to determine where to get properties
   var color = properties_from_strand_3p ? strand_3p.color : strand_5p.color;
-  var idt = properties_from_strand_3p ?  strand_3p.idt : strand_5p.idt;
+  var idt = properties_from_strand_3p ? strand_3p.idt : strand_5p.idt;
 
   // strand_3p is strand whose 3' end is being joined to the other strand's 5' end
   var dna = null;

--- a/lib/src/reducers/strands_reducer.dart
+++ b/lib/src/reducers/strands_reducer.dart
@@ -370,6 +370,7 @@ class InsertionDeletionRecord {
 
 Tuple2<Strand, List<InsertionDeletionRecord>> single_strand_dna_ends_commit_stop_reducer(
     Strand strand, DNAEndsMove all_move, Design design) {
+  String old_sequence = strand.dna_sequence;
   List<InsertionDeletionRecord> records = [];
   List<Substrand> substrands = strand.substrands.toList();
 
@@ -414,8 +415,11 @@ Tuple2<Strand, List<InsertionDeletionRecord>> single_strand_dna_ends_commit_stop
     }
     substrands[i] = new_substrand;
   }
-  return Tuple2<Strand, List<InsertionDeletionRecord>>(
-      strand.rebuild((b) => b..substrands.replace(substrands)), records);
+  strand = strand.rebuild((b) => b..substrands.replace(substrands));
+  if (old_sequence != null) {
+    strand = strand.set_dna_sequence(old_sequence);
+  }
+  return Tuple2<Strand, List<InsertionDeletionRecord>>(strand, records);
 }
 
 List<int> get_remaining_deletions(Domain substrand, int new_offset, DNAEnd dnaend) => substrand.deletions
@@ -519,6 +523,7 @@ Strand idt_fields_remove_reducer(Strand strand, actions.IDTFieldsRemove action) 
   Strand strand_with_new_idt_fields = strand.rebuild((m) => m.idt = null);
   return strand_with_new_idt_fields;
 }
+
 Strand plate_well_idt_fields_remove_reducer(Strand strand, actions.PlateWellIDTFieldsRemove action) {
   if (strand.idt != null) {
     Strand strand_with_new_idt_fields;
@@ -526,7 +531,7 @@ Strand plate_well_idt_fields_remove_reducer(Strand strand, actions.PlateWellIDTF
       ..plate = null
       ..well = null);
     return strand_with_new_idt_fields;
-  }else{
+  } else {
     return strand;
   }
 }

--- a/lib/src/state/strand.dart
+++ b/lib/src/state/strand.dart
@@ -61,7 +61,6 @@ abstract class Strand
       ..color = color
       ..circular = circular
       ..substrands.replace(substrands)
-      ..dna_sequence = dna_sequence
       ..idt = idt?.toBuilder()
       ..modification_5p = modification_5p?.toBuilder()
       ..modification_3p = modification_3p?.toBuilder()
@@ -70,6 +69,10 @@ abstract class Strand
       ..name = name
       ..label = label
       ..unused_fields = MapBuilder<String, Object>({}));
+
+    if (dna_sequence != null) {
+      strand = strand.set_dna_sequence(dna_sequence);
+    }
 
     strand = strand.initialize();
     return strand;
@@ -106,10 +109,6 @@ abstract class Strand
   /// FIXME: remove duplicated code between initialize() and _finalizeBuilder
   Strand initialize() {
     Strand strand = this;
-
-    if (dna_sequence != null) {
-      strand = strand.set_dna_sequence(dna_sequence);
-    }
 
     String id = strand.id;
     int idx = 0;
@@ -178,8 +177,17 @@ abstract class Strand
 
   BuiltList<Substrand> get substrands;
 
-  @nullable
-  String get dna_sequence;
+  @memoized
+  String get dna_sequence {
+    String sequence = "";
+    for (Substrand s in this.substrands) {
+      if (s.dna_sequence == null) {
+        return null;
+      }
+      sequence += s.dna_sequence;
+    }
+    return sequence;
+  }
 
   @nullable
   IDTFields get idt;
@@ -581,9 +589,7 @@ abstract class Strand
       start_idx_ss = end_idx_ss;
     }
 
-    return rebuild((strand) => strand
-      ..substrands.replace(substrands_new)
-      ..dna_sequence = null);
+    return rebuild((strand) => strand..substrands.replace(substrands_new));
   }
 
   /// Sets DNA sequence of strand (but does not assign complement to any Strands bound to it).
@@ -608,9 +614,7 @@ abstract class Strand
       start_idx_ss = end_idx_ss;
     }
 
-    return rebuild((strand) => strand
-      ..substrands.replace(substrands_new)
-      ..dna_sequence = dna_sequence_new);
+    return rebuild((strand) => strand..substrands.replace(substrands_new));
   }
 
   static Strand from_json(Map<String, dynamic> json_map) {

--- a/lib/src/state/strand_maker.dart
+++ b/lib/src/state/strand_maker.dart
@@ -151,8 +151,7 @@ class StrandMaker {
       String purification = constants.default_idt_purification,
       String plate = null,
       String well = null}) {
-    this.idt = IDTFields(
-        scale: scale, purification: purification, plate: plate, well: well);
+    this.idt = IDTFields(scale: scale, purification: purification, plate: plate, well: well);
     return this;
   }
 


### PR DESCRIPTION
## Description
- Replaced Strand.sequence getter with memoized getter. 
- loopout_length_change_reducer and single_strand_dna_ends_commit_stop_reducer logic needed to be updated with to call set_sequence with the old_sequence as an argument to re-set the sequences of substrands.
- nick_reducer is simplified and no longer requires logic dealing with sequence

## Related Issue
#492 

## How Has This Been Tested?
Unit tests

