### PR TITLE
Fixes #492; Refactor Dart data model: store DNA sequence in domains and loopouts, rather in strand

### DIFF
--- a/lib/src/reducers/change_loopout_length.dart
+++ b/lib/src/reducers/change_loopout_length.dart
@@ -130,7 +130,6 @@ BuiltList<Strand> loopouts_length_change_reducer(
 }
 
 Strand loopout_length_change_reducer(Strand strand, actions.LoopoutLengthChange action) {
-  var old_dna_sequence = strand.dna_sequence;
   int loopout_idx = strand.substrands.indexOf(action.loopout);
   var substrands_builder = strand.substrands.toBuilder();
   if (action.length > 0) {
@@ -142,8 +141,5 @@ Strand loopout_length_change_reducer(Strand strand, actions.LoopoutLengthChange 
     substrands_builder.removeAt(loopout_idx);
   }
   strand = strand.rebuild((s) => s..substrands = substrands_builder);
-  if (old_dna_sequence != null) {
-    strand = strand.set_dna_sequence(old_dna_sequence);
-  }
   return strand;
 }

--- a/lib/src/reducers/change_loopout_length.dart
+++ b/lib/src/reducers/change_loopout_length.dart
@@ -130,6 +130,7 @@ BuiltList<Strand> loopouts_length_change_reducer(
 }
 
 Strand loopout_length_change_reducer(Strand strand, actions.LoopoutLengthChange action) {
+  var old_dna_sequence = strand.dna_sequence;
   int loopout_idx = strand.substrands.indexOf(action.loopout);
   var substrands_builder = strand.substrands.toBuilder();
   if (action.length > 0) {
@@ -141,5 +142,8 @@ Strand loopout_length_change_reducer(Strand strand, actions.LoopoutLengthChange 
     substrands_builder.removeAt(loopout_idx);
   }
   strand = strand.rebuild((s) => s..substrands = substrands_builder);
+  if (old_dna_sequence != null) {
+    strand = strand.set_dna_sequence(old_dna_sequence);
+  }
   return strand;
 }

--- a/lib/src/reducers/nick_ligate_join_by_crossover_reducers.dart
+++ b/lib/src/reducers/nick_ligate_join_by_crossover_reducers.dart
@@ -228,13 +228,8 @@ BuiltList<Strand> nick_reducer(BuiltList<Strand> strands, AppState state, action
 
   if (strand.circular) {
     var substrands = substrands_after + substrands_before;
-    String dna_sequence = null;
-    if (strand.dna_sequence != null) {
-      dna_sequence = dna_before + dna_after;
-    }
     var strand_new = strand.rebuild((b) => b
       ..substrands.replace(substrands)
-      ..dna_sequence = dna_sequence
       ..circular = false);
     strand_new = strand_new.initialize();
 
@@ -649,7 +644,7 @@ Strand join_two_strands_with_substrands(
 
   //TODO: use properties_from_strand_3p to determine where to get properties
   var color = properties_from_strand_3p ? strand_3p.color : strand_5p.color;
-  var idt = properties_from_strand_3p ?  strand_3p.idt : strand_5p.idt;
+  var idt = properties_from_strand_3p ? strand_3p.idt : strand_5p.idt;
 
   // strand_3p is strand whose 3' end is being joined to the other strand's 5' end
   var dna = null;

--- a/lib/src/reducers/strands_reducer.dart
+++ b/lib/src/reducers/strands_reducer.dart
@@ -370,7 +370,6 @@ class InsertionDeletionRecord {
 
 Tuple2<Strand, List<InsertionDeletionRecord>> single_strand_dna_ends_commit_stop_reducer(
     Strand strand, DNAEndsMove all_move, Design design) {
-  String old_sequence = strand.dna_sequence;
   List<InsertionDeletionRecord> records = [];
   List<Substrand> substrands = strand.substrands.toList();
 
@@ -416,9 +415,6 @@ Tuple2<Strand, List<InsertionDeletionRecord>> single_strand_dna_ends_commit_stop
     substrands[i] = new_substrand;
   }
   strand = strand.rebuild((b) => b..substrands.replace(substrands));
-  if (old_sequence != null) {
-    strand = strand.set_dna_sequence(old_sequence);
-  }
   return Tuple2<Strand, List<InsertionDeletionRecord>>(strand, records);
 }
 

--- a/lib/src/reducers/strands_reducer.dart
+++ b/lib/src/reducers/strands_reducer.dart
@@ -370,6 +370,7 @@ class InsertionDeletionRecord {
 
 Tuple2<Strand, List<InsertionDeletionRecord>> single_strand_dna_ends_commit_stop_reducer(
     Strand strand, DNAEndsMove all_move, Design design) {
+  String old_sequence = strand.dna_sequence;
   List<InsertionDeletionRecord> records = [];
   List<Substrand> substrands = strand.substrands.toList();
 
@@ -414,8 +415,11 @@ Tuple2<Strand, List<InsertionDeletionRecord>> single_strand_dna_ends_commit_stop
     }
     substrands[i] = new_substrand;
   }
-  return Tuple2<Strand, List<InsertionDeletionRecord>>(
-      strand.rebuild((b) => b..substrands.replace(substrands)), records);
+  strand = strand.rebuild((b) => b..substrands.replace(substrands));
+  if (old_sequence != null) {
+    strand = strand.set_dna_sequence(old_sequence);
+  }
+  return Tuple2<Strand, List<InsertionDeletionRecord>>(strand, records);
 }
 
 List<int> get_remaining_deletions(Domain substrand, int new_offset, DNAEnd dnaend) => substrand.deletions
@@ -519,6 +523,7 @@ Strand idt_fields_remove_reducer(Strand strand, actions.IDTFieldsRemove action) 
   Strand strand_with_new_idt_fields = strand.rebuild((m) => m.idt = null);
   return strand_with_new_idt_fields;
 }
+
 Strand plate_well_idt_fields_remove_reducer(Strand strand, actions.PlateWellIDTFieldsRemove action) {
   if (strand.idt != null) {
     Strand strand_with_new_idt_fields;
@@ -526,7 +531,7 @@ Strand plate_well_idt_fields_remove_reducer(Strand strand, actions.PlateWellIDTF
       ..plate = null
       ..well = null);
     return strand_with_new_idt_fields;
-  }else{
+  } else {
     return strand;
   }
 }

--- a/lib/src/state/strand.dart
+++ b/lib/src/state/strand.dart
@@ -61,7 +61,6 @@ abstract class Strand
       ..color = color
       ..circular = circular
       ..substrands.replace(substrands)
-      ..dna_sequence = dna_sequence
       ..idt = idt?.toBuilder()
       ..modification_5p = modification_5p?.toBuilder()
       ..modification_3p = modification_3p?.toBuilder()
@@ -70,6 +69,10 @@ abstract class Strand
       ..name = name
       ..label = label
       ..unused_fields = MapBuilder<String, Object>({}));
+
+    if (dna_sequence != null) {
+      strand = strand.set_dna_sequence(dna_sequence);
+    }
 
     strand = strand.initialize();
     return strand;
@@ -106,10 +109,6 @@ abstract class Strand
   /// FIXME: remove duplicated code between initialize() and _finalizeBuilder
   Strand initialize() {
     Strand strand = this;
-
-    if (dna_sequence != null) {
-      strand = strand.set_dna_sequence(dna_sequence);
-    }
 
     String id = strand.id;
     int idx = 0;
@@ -178,8 +177,17 @@ abstract class Strand
 
   BuiltList<Substrand> get substrands;
 
-  @nullable
-  String get dna_sequence;
+  @memoized
+  String get dna_sequence {
+    String sequence = "";
+    for (Substrand s in this.substrands) {
+      if (s.dna_sequence == null) {
+        return null;
+      }
+      sequence += s.dna_sequence;
+    }
+    return sequence;
+  }
 
   @nullable
   IDTFields get idt;
@@ -581,9 +589,7 @@ abstract class Strand
       start_idx_ss = end_idx_ss;
     }
 
-    return rebuild((strand) => strand
-      ..substrands.replace(substrands_new)
-      ..dna_sequence = null);
+    return rebuild((strand) => strand..substrands.replace(substrands_new));
   }
 
   /// Sets DNA sequence of strand (but does not assign complement to any Strands bound to it).
@@ -608,9 +614,7 @@ abstract class Strand
       start_idx_ss = end_idx_ss;
     }
 
-    return rebuild((strand) => strand
-      ..substrands.replace(substrands_new)
-      ..dna_sequence = dna_sequence_new);
+    return rebuild((strand) => strand..substrands.replace(substrands_new));
   }
 
   static Strand from_json(Map<String, dynamic> json_map) {

--- a/lib/src/state/strand_maker.dart
+++ b/lib/src/state/strand_maker.dart
@@ -151,8 +151,7 @@ class StrandMaker {
       String purification = constants.default_idt_purification,
       String plate = null,
       String well = null}) {
-    this.idt = IDTFields(
-        scale: scale, purification: purification, plate: plate, well: well);
+    this.idt = IDTFields(scale: scale, purification: purification, plate: plate, well: well);
     return this;
   }
 

--- a/test/reducer_test.dart
+++ b/test/reducer_test.dart
@@ -7564,6 +7564,96 @@ main() {
     expect(new_helix0_svg.y, closeTo(helix0_svg.y, 0.001));
     expect(new_helix2_svg.y, closeTo(helix1_svg.y, 0.001));
   });
+
+  // Setup:
+  //      domain1
+  //     AAAAAAAA
+  //   0 [-------
+  //            |
+  //   1 <-------
+  //     GGGGGGGG
+  //     domain2
+  //
+  // Action: Move 5' end to the right
+  //
+  // Expected Result:
+  //     domain1
+  //         AAAA
+  //   0     [---
+  //            |
+  //   1 <-------
+  //     GGGGGGGG
+  //     domain2
+  //
+  //   domain2 sequence should remain unchanged, domain1 should trim
+  test('dna_ends_move_should_change_domain_sequence_locally__trim', () {
+    // Setup:
+    Helix helix0 = Helix(idx: 0, grid_position: GridPosition(0, 0), max_offset: 8);
+    Helix helix1 = Helix(idx: 1, grid_position: GridPosition(0, 1), max_offset: 8);
+    Design design = Design(helices: [helix0, helix1], grid: Grid.square)
+        .strand(0, 0)
+        .to(8)
+        .cross(1)
+        .to(0)
+        .with_sequence('AAAAAAAAGGGGGGGG')
+        .commit();
+    AppState state = app_state_from_design(design);
+
+    // Action:
+    DNAEndMove move =
+        DNAEndMove(dna_end: design.strands.first.dnaend_5p, lowest_offset: 0, highest_offset: 8);
+    DNAEndsMove dna_ends_move =
+        DNAEndsMove(moves: [move].build(), original_offset: 0, current_offset: 4, helix: helix0);
+    AppState new_state = app_state_reducer(state, DNAEndsMoveCommit(dna_ends_move: dna_ends_move));
+
+    // Expected Result:
+    expect(new_state.design.strands.first.dna_sequence, 'AAAAGGGGGGGG');
+  });
+
+  // Setup:
+  //      domain1
+  //     AAAAAAAA
+  //   0 ------->
+  //     |
+  //   1 -------]
+  //     GGGGGGGG
+  //     domain2
+  //
+  // Action: Move 5' end to the right
+  //
+  // Expected Result:
+  //      domain1
+  //     AAAAAAAA
+  //   0 ------->
+  //     |
+  //   1 ----------]
+  //     ???GGGGGGGG
+  //     domain2
+  //
+  //   domain1 sequence should remain unchanged, domain2 should pad
+  test('dna_ends_move_should_change_domain_sequence_locally__pad', () {
+    // Setup:
+    Helix helix0 = Helix(idx: 0, grid_position: GridPosition(0, 0), max_offset: 16);
+    Helix helix1 = Helix(idx: 1, grid_position: GridPosition(0, 1), max_offset: 16);
+    Design design = Design(helices: [helix0, helix1], grid: Grid.square)
+        .strand(1, 8)
+        .to(0)
+        .cross(0)
+        .to(8)
+        .with_sequence('GGGGGGGGAAAAAAAA')
+        .commit();
+    AppState state = app_state_from_design(design);
+
+    // Action:
+    DNAEndMove move =
+        DNAEndMove(dna_end: design.strands.first.dnaend_5p, lowest_offset: 0, highest_offset: 16);
+    DNAEndsMove dna_ends_move =
+        DNAEndsMove(moves: [move].build(), original_offset: 7, current_offset: 10, helix: helix1);
+    AppState new_state = app_state_reducer(state, DNAEndsMoveCommit(dna_ends_move: dna_ends_move));
+
+    // Expected Result:
+    expect(new_state.design.strands.first.dna_sequence, 'GGGGGGGG???AAAAAAAA');
+  });
 }
 
 AppState make_ends_selectable(AppState actual_state) {

--- a/test/reducer_test.dart
+++ b/test/reducer_test.dart
@@ -4247,7 +4247,7 @@ main() {
           r'''", "grid": "square", "helices": [ {"grid_position": [0, 0]} ],
           "strands": [
           {
-            "sequence": "AGTCAGTCAGTCAGTCAATTGACTGACTGACTGACT",
+            "sequence": "AGTCAGTCAGTCAGTCAATT?GACTGACTGACTGACT",
             "domains": [
               {"helix": 0, "forward": true,  "start": 0, "end": 16},
               {"loopout": 5},
@@ -4270,7 +4270,7 @@ main() {
           r'''", "grid": "square", "helices": [ {"grid_position": [0, 0]} ],
           "strands": [
           {
-            "sequence": "AGTCAGTCAGTCAGTCAATTGACTGACTGACTGACT",
+            "sequence": "AGTCAGTCAGTCAGTCAATGACTGACTGACTGACT",
             "domains": [
               {"helix": 0, "forward": true,  "start": 0, "end": 16},
               {"loopout": 3},
@@ -4304,7 +4304,7 @@ main() {
           r'''", "grid": "square", "helices": [ {"grid_position": [0, 0]} ],
           "strands": [
           {
-            "sequence": "AGTCAGTCAGTCAGTCAATTGACTGACTGACTGACT",
+            "sequence": "AGTCAGTCAGTCAGTCGACTGACTGACTGACT",
             "domains": [
               {"helix": 0, "forward": true,  "start": 0, "end": 16},
               {"helix": 0, "forward": false,  "start": 0, "end": 16}


### PR DESCRIPTION
## Description
- Replaced Strand.sequence getter with memoized getter.
- Refactor `Strand.initialize()` into smaller functions to improve readability and code reuse
- Add logic to Strand.initialize to maintain the following invariants:
    - Either all substrands dna sequence are null or none of them are null
    - If substrand has dna sequence, it will be same length as substrand length (question marks padding)
- ~~loopout_length_change_reducer and single_strand_dna_ends_commit_stop_reducer logic needed to be updated with to call set_sequence with the old_sequence as an argument to re-set the sequences of substrands.~~ (after meeting with Dave we decided that sequence changes should be kept local for more intuitive behavior)
- [`nick_reducer()` is simplified and no longer requires logic dealing with sequence](https://github.com/UC-Davis-molecular-computing/scadnano/pull/754/files#diff-99573d0bb79fb06d93467d14fd404803fc1cfa1ece2c27e93b259bb2dfc4d953)
- [Change loopout unit tests so that expected behavior is now localize changes rather than global changes](https://github.com/UC-Davis-molecular-computing/scadnano/pull/754/files#diff-ed63b52cee4597c9acd3c8f7436f8713a03ba90982b67d245d4b022ce6f3201dL4250-R4307)
- [Add unit tests to check that moving DNA ends change sequences locally rather than globally](https://github.com/UC-Davis-molecular-computing/scadnano/pull/754/files#diff-ed63b52cee4597c9acd3c8f7436f8713a03ba90982b67d245d4b022ce6f3201dR7567-R7656)

## Related Issue
#492 

## How Has This Been Tested?
Unit tests

