### PR TITLE
fixes #761: undo "inline insertions/deletions" should undo setting of helix tick marks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,15 @@ abstract class StrandPasteKeepColorSet
 
 As you can see, there's quite a bit of boilerplate code, not only below the comment line, but also in the lines declaring the class.
 
+The built_value library allows a useful feature called *memoized getters*: these are fields that are calculated from other fields, for example, `Helix.num_bases` is calculated based on the values of `Helix.min_offset` and `Helix.max_offset`. By marking such a field as memoized, it is not calculated until the first time it is accessed, and then the value is stored so that it does not need to be recalculated. (This is safe to do since the immutability of the object ensures that no other field values will update and changed the correct value of this memoized field.) For example, here is how `Helix.num_bases` is calculated:
+
+```dart
+  @memoized
+  int get num_bases => this.max_offset - this.min_offset;
+```
+
+**Memoized fields should return immutable objects**: WARNING: memoized fields should always return immutable objects. Otherwise there can be errors where a field is not properly updated when it should be. For example, the bug in issue [#761](https://github.com/UC-Davis-molecular-computing/scadnano/issues/761) was caused by the memoized getter `Helix.calculate_major_ticks` returning a `List<int>` instead of a `BuiltList<int>`.
+
 Another disadvantage of built_value is that it (as well as OverReact) uses *code generation* (on compiling, first some extra code is generated that implement many of the features), and there are so many built_value and OverReact classes that the compilation time for the project, at the time of this writing, is 20 seconds minimum, and often more like 30-70 seconds, depending on your system. So although Dart's dartdevc incremental compiler is nice in allowing you to make one change to code, save it, and have dartdevc (run through `webdev serve` when developing locally) re-run and show the changed code in the browser (after a browser refresh), it does take a bit of time.
 
 Another thing to note is that many IDEs and editors come with a static analysis tool that will warn about errors. Prior to the code generation running, the analyzer will report many errors, because the code written refers to types that don't exist yet, but that will be generated when the compilation is successful. This can make it difficult to track down compilation errors, because some are "real" (i.e., you made a mistake), and some are artifacts of this process that will go away once the compilation is successful. Even worse, OverReact's code generation retains the errors until the analyzer is refreshed; so even after successfully compiling, the analyzer will warn about errors. In WebStorm, this can be refreshed by clicking "Dart Analysis" at the bottom of the screen, and then clicking the "Restart Dart Analysis Server" button (circular red arrow).

--- a/lib/src/reducers/inline_insertions_deletions_reducer.dart
+++ b/lib/src/reducers/inline_insertions_deletions_reducer.dart
@@ -63,7 +63,7 @@ _inline_deletions_insertions_on_helix(
   dels_ins_offsets_sorted.sort();
 
   // fix helix major ticks
-  List<int> major_ticks = helix.calculate_major_ticks;
+  List<int> major_ticks = helix.calculate_major_ticks.toList();
   major_ticks.sort();
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/lib/src/state/design.dart
+++ b/lib/src/state/design.dart
@@ -150,7 +150,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
   BuiltMap<int, Helix> helices_in_group(String group_name) =>
       BuiltMap<int, Helix>.from(helices.toMap()..removeWhere((idx, helix) => helix.group != group_name));
 
-  StrandMaker strand(int current_helix, int current_offset) {
+  StrandMaker draw_strand(int current_helix, int current_offset) {
     return StrandMaker(this, current_helix, current_offset);
   }
 
@@ -470,7 +470,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
     return map.build();
   }
 
-  /// design.strands_overlapping[strand] is a list of all strands that overlap strand, including possibly itself.
+  /// design.strands_overlapping[draw_strand] is a list of all strands that overlap strand, including possibly itself.
   @memoized
   BuiltMap<Strand, BuiltList<Strand>> get strands_overlapping {
     Map<Strand, List<Strand>> map = {};
@@ -2355,6 +2355,8 @@ class IllegalDesignError implements Exception {
   String cause;
 
   IllegalDesignError(this.cause);
+
+  bool operator ==(Object other) => other is IllegalDesignError;
 }
 
 class IllegalCadnanoDesignError implements IllegalDesignError {

--- a/lib/src/state/helix.dart
+++ b/lib/src/state/helix.dart
@@ -56,6 +56,7 @@ abstract class Helix with BuiltJsonSerializable, UnusedFields implements Built<H
     bool invert_y = false,
     Position3D position = null,
     Point<num> svg_position = null,
+    Iterable<int> major_tick_periodic_distances = null,
     String group = constants.default_group_name,
   }) {
     if (grid == null) {
@@ -70,6 +71,9 @@ abstract class Helix with BuiltJsonSerializable, UnusedFields implements Built<H
     if (grid_position == null && grid != Grid.none) {
       grid_position = GridPosition(0, idx);
     }
+    if (major_tick_periodic_distances == null) {
+      major_tick_periodic_distances = [];
+    }
     return Helix.from((b) => b
       ..idx = idx
       ..geometry = geometry?.toBuilder()
@@ -81,6 +85,7 @@ abstract class Helix with BuiltJsonSerializable, UnusedFields implements Built<H
       ..min_offset = min_offset
       ..max_offset = max_offset
       ..major_tick_start = major_tick_start
+      ..major_tick_periodic_distances.replace(major_tick_periodic_distances)
       ..unused_fields.replace({}));
   }
 

--- a/lib/src/state/helix.dart
+++ b/lib/src/state/helix.dart
@@ -365,7 +365,7 @@ abstract class Helix with BuiltJsonSerializable, UnusedFields implements Built<H
   /// They are used in reverse order to determine precedence. (e.g., [Helix.major_ticks]
   /// overrides [Helix.major_tick_distance].
   @memoized
-  List<int> get calculate_major_ticks {
+  BuiltList<int> get calculate_major_ticks {
     List<int> ticks = [];
     if (has_major_ticks) {
       var sorted_ticks = major_ticks.toList();
@@ -387,6 +387,6 @@ abstract class Helix with BuiltJsonSerializable, UnusedFields implements Built<H
         ticks = [for (int tick = major_tick_start; tick <= max_offset; tick += distance) tick];
       }
     }
-    return ticks;
+    return ticks.build();
   }
 }

--- a/lib/src/view/design_main_helix.dart
+++ b/lib/src/view/design_main_helix.dart
@@ -165,7 +165,7 @@ class DesignMainHelixComponent extends UiComponent2<DesignMainHelixProps> with P
   final num DISTANCE_OFFSET_DISPLAY_FROM_HELIX = 3;
 
   _major_tick_offsets_svg_group() {
-    List<int> major_ticks = props.helix.calculate_major_ticks;
+    BuiltList<int> major_ticks = props.helix.calculate_major_ticks;
 
     // offset if DNA sequences and/or domain labels are present
     num offset = 0;
@@ -198,7 +198,7 @@ class DesignMainHelixComponent extends UiComponent2<DesignMainHelixProps> with P
   }
 
   _major_tick_widths_svg_group() {
-    List<int> major_ticks = props.helix.calculate_major_ticks;
+    BuiltList<int> major_ticks = props.helix.calculate_major_ticks;
 
     // offset if DNA sequences and/or domain labels are present
     num offset = 0;
@@ -261,7 +261,7 @@ class DesignMainHelixComponent extends UiComponent2<DesignMainHelixProps> with P
 
   /// Return Map {'minor': thin_lines, 'major': thick_lines} to paths describing minor and major vertical lines.
   Map<String, String> _vert_line_paths(Helix helix, num helix_svg_position_y) {
-    List<int> major_ticks = helix.calculate_major_ticks;
+    BuiltList<int> major_ticks = helix.calculate_major_ticks;
 //  var major_tick_distance =
 //      helix.has_major_tick_distance() ? helix.major_tick_distance : design_major_tick_distance;
 //  Set<int> major_ticks = (helix.has_major_ticks()

--- a/test/assign_dna_unit_test.dart
+++ b/test/assign_dna_unit_test.dart
@@ -34,8 +34,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(16).commit();
-      design = design.strand(0, 16).move(-16).commit();
+      design = design.draw_strand(0, 0).move(16).commit();
+      design = design.draw_strand(0, 16).move(-16).commit();
       AppState state = app_state_from_design(design);
       Strand strand = design.strands.first;
       String dna_sequence = 'AACGTACGATGCATCC';
@@ -94,7 +94,7 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 5, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(5).loopout(0, 5).move(-5).commit();
+      design = design.draw_strand(0, 0).move(5).loopout(0, 5).move(-5).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand = design.strands.first;
@@ -144,9 +144,9 @@ main() {
       ];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(5).loopout(1, 5).move(-5).commit();
-      design = design.strand(0, 5).move(-5).commit();
-      design = design.strand(1, 0).move(5).commit();
+      design = design.draw_strand(0, 0).move(5).loopout(1, 5).move(-5).commit();
+      design = design.draw_strand(0, 5).move(-5).commit();
+      design = design.draw_strand(1, 0).move(5).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand = design.strands.first;
@@ -202,9 +202,9 @@ main() {
       ];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(5).loopout(1, 5).move(-5).commit();
-      design = design.strand(0, 5).move(-5).commit();
-      design = design.strand(1, 0).move(5).commit();
+      design = design.draw_strand(0, 0).move(5).loopout(1, 5).move(-5).commit();
+      design = design.draw_strand(0, 5).move(-5).commit();
+      design = design.draw_strand(1, 0).move(5).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand = design.strands[1];
@@ -285,8 +285,8 @@ main() {
       ];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 4).move(4).cross(1).move(-8).cross(0).move(4).commit();
-      design = design.strand(0, 8).move(-8).commit();
+      design = design.draw_strand(0, 4).move(4).cross(1).move(-8).cross(0).move(4).commit();
+      design = design.draw_strand(0, 8).move(-8).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand = design.strands[0];
@@ -333,8 +333,8 @@ main() {
       ];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 4).move(4).cross(1).move(-8).cross(0).move(4).commit();
-      design = design.strand(0, 8).move(-8).commit();
+      design = design.draw_strand(0, 4).move(4).cross(1).move(-8).cross(0).move(4).commit();
+      design = design.draw_strand(0, 8).move(-8).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand = design.strands[1];
@@ -377,8 +377,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 10, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(8).commit();
-      design = design.strand(0, 4).move(-4).commit();
+      design = design.draw_strand(0, 0).move(8).commit();
+      design = design.draw_strand(0, 4).move(-4).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand1 = design.strands[0];
@@ -432,8 +432,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 10, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(8).commit();
-      design = design.strand(0, 6).move(-4).commit();
+      design = design.draw_strand(0, 0).move(8).commit();
+      design = design.draw_strand(0, 6).move(-4).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand1 = design.strands[0];
@@ -476,8 +476,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 10, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(5).commit();
-      design = design.strand(0, 5).move(-5).commit();
+      design = design.draw_strand(0, 0).move(5).commit();
+      design = design.draw_strand(0, 5).move(-5).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand = design.strands.last;
@@ -508,8 +508,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 10, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(5).commit();
-      design = design.strand(0, 5).move(-5).commit();
+      design = design.draw_strand(0, 0).move(5).commit();
+      design = design.draw_strand(0, 5).move(-5).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand = design.strands.last;
@@ -540,9 +540,9 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 10, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(8).commit();
-      design = design.strand(0, 4).move(-4).commit();
-      design = design.strand(0, 8).move(-4).commit();
+      design = design.draw_strand(0, 0).move(8).commit();
+      design = design.draw_strand(0, 4).move(-4).commit();
+      design = design.draw_strand(0, 8).move(-4).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand1 = design.strands[1];
@@ -590,10 +590,10 @@ main() {
       ];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(1, 0).move(6).cross(0).move(-6).commit();
-      design = design.strand(0, 2).move(8).cross(1).move(-8).commit();
-      design = design.strand(0, 12).move(-6).commit();
-      design = design.strand(1, 6).move(6).commit();
+      design = design.draw_strand(1, 0).move(6).cross(0).move(-6).commit();
+      design = design.draw_strand(0, 2).move(8).cross(1).move(-8).commit();
+      design = design.draw_strand(0, 12).move(-6).commit();
+      design = design.draw_strand(1, 6).move(6).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand1 = design.strands[2];
@@ -656,9 +656,9 @@ main() {
       ];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(1, 0).move(6).cross(0).move(-6).add_deletion(0, 3).commit();
+      design = design.draw_strand(1, 0).move(6).cross(0).move(-6).add_deletion(0, 3).commit();
       design = design
-          .strand(0, 2)
+          .draw_strand(0, 2)
           .move(8)
           .add_deletion(0, 3)
           .add_deletion(0, 8)
@@ -666,8 +666,8 @@ main() {
           .move(-8)
           .add_deletion(1, 8)
           .commit();
-      design = design.strand(0, 12).move(-6).add_deletion(0, 8).commit();
-      design = design.strand(1, 6).move(6).add_deletion(1, 8).commit();
+      design = design.draw_strand(0, 12).move(-6).add_deletion(0, 8).commit();
+      design = design.draw_strand(1, 6).move(6).add_deletion(1, 8).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand1 = design.strands[2];
@@ -729,17 +729,17 @@ main() {
       ];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(1, 0).move(6).cross(0).move(-6).commit();
+      design = design.draw_strand(1, 0).move(6).cross(0).move(-6).commit();
       design = design
-          .strand(0, 2)
+          .draw_strand(0, 2)
           .move(8)
           .add_insertion(0, 8, 1)
           .cross(1)
           .move(-8)
           .add_insertion(1, 8, 1)
           .commit();
-      design = design.strand(0, 12).move(-6).add_insertion(0, 8, 1).commit();
-      design = design.strand(1, 6).move(6).add_insertion(1, 8, 1).commit();
+      design = design.draw_strand(0, 12).move(-6).add_insertion(0, 8, 1).commit();
+      design = design.draw_strand(1, 6).move(6).add_insertion(1, 8, 1).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand1 = design.strands[2];
@@ -795,8 +795,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 10, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(10).commit();
-      design = design.strand(0, 5).move(-5).commit();
+      design = design.draw_strand(0, 0).move(10).commit();
+      design = design.draw_strand(0, 5).move(-5).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand = design.strands.last;
@@ -827,8 +827,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 10, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(5).commit();
-      design = design.strand(0, 10).move(-10).commit();
+      design = design.draw_strand(0, 0).move(5).commit();
+      design = design.draw_strand(0, 10).move(-10).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand = design.strands.first;
@@ -862,8 +862,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 10, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 5).move(-5).commit();
-      design = design.strand(0, 0).move(10).move(-3).commit();
+      design = design.draw_strand(0, 5).move(-5).commit();
+      design = design.draw_strand(0, 0).move(10).move(-3).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand = design.strands.first;
@@ -900,8 +900,8 @@ main() {
       ];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 10).move(-5).commit();
-      design = design.strand(0, 0).move(10).cross(1).move(-3).commit();
+      design = design.draw_strand(0, 10).move(-5).commit();
+      design = design.draw_strand(0, 0).move(10).cross(1).move(-3).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand = design.strands.first;
@@ -932,10 +932,10 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 10, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 9).move(-9).commit();
-      design = design.strand(0, 0).move(3).commit();
-      design = design.strand(0, 3).move(3).commit();
-      design = design.strand(0, 6).move(3).commit();
+      design = design.draw_strand(0, 9).move(-9).commit();
+      design = design.draw_strand(0, 0).move(3).commit();
+      design = design.draw_strand(0, 3).move(3).commit();
+      design = design.draw_strand(0, 6).move(3).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand = design.strands.first;
@@ -972,9 +972,9 @@ main() {
       ];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(12).cross(1).move(-12).commit();
-      design = design.strand(0, 3).move(-3).cross(1).move(6).cross(0).move(-3).commit();
-      design = design.strand(1, 9).move(3).cross(0).move(-6).cross(1).move(3).commit();
+      design = design.draw_strand(0, 0).move(12).cross(1).move(-12).commit();
+      design = design.draw_strand(0, 3).move(-3).cross(1).move(6).cross(0).move(-3).commit();
+      design = design.draw_strand(1, 9).move(3).cross(0).move(-6).cross(1).move(3).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand = design.strands.first;
@@ -1009,8 +1009,8 @@ main() {
       ];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(1, 16).move(-16).cross(0).move(16).commit();
-      design = design.strand(1, 0).move(16).cross(0).move(-16).commit();
+      design = design.draw_strand(1, 16).move(-16).cross(0).move(16).commit();
+      design = design.draw_strand(1, 0).move(16).cross(0).move(-16).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand = design.strands.first;
@@ -1053,7 +1053,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(1, 3)
+          .draw_strand(1, 3)
           .move(-3)
           .add_deletion(1, 1)
           .cross(0)
@@ -1064,8 +1064,8 @@ main() {
           .move(-3)
           .add_deletion(1, 4)
           .commit();
-      design = design.strand(1, 0).move(3).add_deletion(1, 1).cross(0).move(-3).add_deletion(0, 1).commit();
-      design = design.strand(0, 6).move(-3).add_deletion(0, 4).cross(1).move(3).add_deletion(1, 4).commit();
+      design = design.draw_strand(1, 0).move(3).add_deletion(1, 1).cross(0).move(-3).add_deletion(0, 1).commit();
+      design = design.draw_strand(0, 6).move(-3).add_deletion(0, 4).cross(1).move(3).add_deletion(1, 4).commit();
 
       AppState state = app_state_from_design(design);
       Strand strand = design.strands.first;
@@ -1097,10 +1097,10 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 9, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(3).commit();
-      design = design.strand(0, 3).move(3).commit();
-      design = design.strand(0, 6).move(3).commit();
-      design = design.strand(0, 9).move(-9).commit();
+      design = design.draw_strand(0, 0).move(3).commit();
+      design = design.draw_strand(0, 3).move(3).commit();
+      design = design.draw_strand(0, 6).move(3).commit();
+      design = design.draw_strand(0, 9).move(-9).commit();
 
       AppState state = app_state_from_design(design);
 
@@ -1143,8 +1143,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(16).with_sequence("AACGTACGATGCATCC").commit();
-      design = design.strand(0, 16).move(-16).with_sequence("GGATGCATCGTACGTT").commit();
+      design = design.draw_strand(0, 0).move(16).with_sequence("AACGTACGATGCATCC").commit();
+      design = design.draw_strand(0, 16).move(-16).with_sequence("GGATGCATCGTACGTT").commit();
       AppState state = app_state_from_design(design);
       Strand strand = design.strands.last;
       state =
@@ -1161,8 +1161,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(16).with_sequence('AACGTACGATGCATCC').commit();
-      design = design.strand(0, 16).move(-16).commit();
+      design = design.draw_strand(0, 0).move(16).with_sequence('AACGTACGATGCATCC').commit();
+      design = design.draw_strand(0, 16).move(-16).commit();
 
       var action = actions.AssignDNAComplementFromBoundStrands(design.strands);
       var state = app_state_from_design(design);
@@ -1185,8 +1185,8 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design =
-          design.strand(0, 0).move(16).add_insertion(0, 8, 3).with_sequence('AACGTATCGCGATGCATCC').commit();
-      design = design.strand(0, 16).move(-16).add_insertion(0, 8, 3).commit();
+          design.draw_strand(0, 0).move(16).add_insertion(0, 8, 3).with_sequence('AACGTATCGCGATGCATCC').commit();
+      design = design.draw_strand(0, 16).move(-16).add_insertion(0, 8, 3).commit();
 
       var action = actions.AssignDNAComplementFromBoundStrands([design.strands[1]]);
       var state = app_state_from_design(design);
@@ -1210,9 +1210,9 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(16).add_insertion(0, 8, 3).commit();
-      design = design.strand(0, 5).move(-5).with_sequence("ACGTT").commit();
-      design = design.strand(0, 16).move(-11).add_insertion(0, 8, 3).with_sequence('GGATGCATCGCGAT').commit();
+      design = design.draw_strand(0, 0).move(16).add_insertion(0, 8, 3).commit();
+      design = design.draw_strand(0, 5).move(-5).with_sequence("ACGTT").commit();
+      design = design.draw_strand(0, 16).move(-11).add_insertion(0, 8, 3).with_sequence('GGATGCATCGCGAT').commit();
 
       var action = actions.AssignDNAComplementFromBoundStrands([design.strands[0]]);
       var state = app_state_from_design(design);
@@ -1236,8 +1236,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(16).add_deletion(0, 8).with_sequence('AACGTACGTGCATCC').commit();
-      design = design.strand(0, 16).move(-16).add_deletion(0, 8).commit();
+      design = design.draw_strand(0, 0).move(16).add_deletion(0, 8).with_sequence('AACGTACGTGCATCC').commit();
+      design = design.draw_strand(0, 16).move(-16).add_deletion(0, 8).commit();
 
       var action = actions.AssignDNAComplementFromBoundStrands([design.strands[1]]);
       var state = app_state_from_design(design);
@@ -1259,9 +1259,9 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(16).add_deletion(0, 8).commit();
-      design = design.strand(0, 5).move(-5).with_sequence("ACGTT").commit();
-      design = design.strand(0, 16).move(-11).add_deletion(0, 8).with_sequence('TGCATCGGAT').commit();
+      design = design.draw_strand(0, 0).move(16).add_deletion(0, 8).commit();
+      design = design.draw_strand(0, 5).move(-5).with_sequence("ACGTT").commit();
+      design = design.draw_strand(0, 16).move(-11).add_deletion(0, 8).with_sequence('TGCATCGGAT').commit();
 
       var action = actions.AssignDNAComplementFromBoundStrands([design.strands[0]]);
       var state = app_state_from_design(design);

--- a/test/assign_domain_name_complement_domain_test.dart
+++ b/test/assign_domain_name_complement_domain_test.dart
@@ -33,7 +33,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(8)
           .with_domain_name("ABC")
           .cross(0)
@@ -69,7 +69,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(9)
           .with_domain_name("ABC")
           .cross(0)
@@ -99,7 +99,7 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(8).cross(0).move(-8).commit();
+      design = design.draw_strand(0, 0).move(8).cross(0).move(-8).commit();
 
       var action = actions.AssignDomainNameComplementFromBoundDomains(design.all_domains);
       var state = app_state_from_design(design);
@@ -123,8 +123,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(8).with_domain_name("ABC").commit();
-      design = design.strand(0, 8).move(-8).with_domain_name("XYZ").commit();
+      design = design.draw_strand(0, 0).move(8).with_domain_name("ABC").commit();
+      design = design.draw_strand(0, 8).move(-8).with_domain_name("XYZ").commit();
 
       var action = actions.AssignDomainNameComplementFromBoundDomains(design.all_domains);
       var state = app_state_from_design(design);
@@ -153,8 +153,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(9).with_domain_name("ABC").commit();
-      design = design.strand(0, 8).move(-8).with_domain_name("XYZ").commit();
+      design = design.draw_strand(0, 0).move(9).with_domain_name("ABC").commit();
+      design = design.draw_strand(0, 8).move(-8).with_domain_name("XYZ").commit();
 
       var action = actions.AssignDomainNameComplementFromBoundDomains(design.all_domains);
       var state = app_state_from_design(design);
@@ -177,8 +177,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(8).commit();
-      design = design.strand(0, 8).move(-8).commit();
+      design = design.draw_strand(0, 0).move(8).commit();
+      design = design.draw_strand(0, 8).move(-8).commit();
 
       var action = actions.AssignDomainNameComplementFromBoundDomains(design.all_domains);
       var state = app_state_from_design(design);
@@ -201,8 +201,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(8).commit();
-      design = design.strand(0, 8).move(-8).commit();
+      design = design.draw_strand(0, 0).move(8).commit();
+      design = design.draw_strand(0, 8).move(-8).commit();
 
       var action = actions.AssignDomainNameComplementFromBoundDomains(design.all_domains);
       var state = app_state_from_design(design);
@@ -229,8 +229,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(8).with_domain_name("ABC").commit();
-      design = design.strand(0, 8).move(-8).with_domain_name("XYZ").commit();
+      design = design.draw_strand(0, 0).move(8).with_domain_name("ABC").commit();
+      design = design.draw_strand(0, 8).move(-8).with_domain_name("XYZ").commit();
 
       var action = actions.AssignDomainNameComplementFromBoundDomains([design.all_domains[0]]);
       var state = app_state_from_design(design);
@@ -254,8 +254,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(9).with_domain_name("ABC").commit();
-      design = design.strand(0, 8).move(-8).with_domain_name("XYZ").commit();
+      design = design.draw_strand(0, 0).move(9).with_domain_name("ABC").commit();
+      design = design.draw_strand(0, 8).move(-8).with_domain_name("XYZ").commit();
 
       var action = actions.AssignDomainNameComplementFromBoundDomains([design.all_domains[0]]);
       var state = app_state_from_design(design);
@@ -279,8 +279,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(8).commit();
-      design = design.strand(0, 8).move(-8).commit();
+      design = design.draw_strand(0, 0).move(8).commit();
+      design = design.draw_strand(0, 8).move(-8).commit();
 
       var action = actions.AssignDomainNameComplementFromBoundDomains([design.all_domains[0]]);
       var state = app_state_from_design(design);
@@ -304,8 +304,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(9).commit();
-      design = design.strand(0, 8).move(-8).commit();
+      design = design.draw_strand(0, 0).move(9).commit();
+      design = design.draw_strand(0, 8).move(-8).commit();
 
       var action = actions.AssignDomainNameComplementFromBoundDomains([design.all_domains[0]]);
       var state = app_state_from_design(design);
@@ -331,7 +331,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(8)
           .with_domain_name("ABC")
           .cross(0)
@@ -359,7 +359,7 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(8).cross(0).move(-8).with_domain_name("DEF").commit();
+      design = design.draw_strand(0, 0).move(8).cross(0).move(-8).with_domain_name("DEF").commit();
 
       var action = actions.AssignDomainNameComplementFromBoundDomains(design.all_domains);
       var state = app_state_from_design(design);
@@ -382,7 +382,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(8)
           .with_domain_name("JKL")
           .cross(0, 4)
@@ -413,7 +413,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(8)
           .with_domain_name("ABC")
           .cross(0)
@@ -452,7 +452,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(8)
           .with_domain_name("ABC")
           .cross(0)
@@ -482,7 +482,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(8)
           .with_domain_name("ABC")
           .cross(0)
@@ -511,7 +511,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(8)
           .with_domain_name("ABC")
           .cross(0)
@@ -541,7 +541,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(8)
           .with_domain_name("JKL")
           .cross(0)
@@ -568,7 +568,7 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(8).with_domain_name("JKL").cross(0).move(-6).commit();
+      design = design.draw_strand(0, 0).move(8).with_domain_name("JKL").cross(0).move(-6).commit();
 
       var action = actions.AssignDomainNameComplementFromBoundDomains([design.all_domains[1]]);
       var state = app_state_from_design(design);

--- a/test/assign_domain_name_complement_strand_test.dart
+++ b/test/assign_domain_name_complement_strand_test.dart
@@ -44,11 +44,11 @@ main() {
       ];
       design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(1, 16).move(-16).cross(0).move(32).loopout(1, 3).move(-16).with_domain_name("DEF*").as_scaffold().commit();
-      design = design.strand(1, 0).move(16).with_domain_name("ABC").cross(0).move(-16).commit();
-      design = design.strand(0, 32).move(-16).with_domain_name("GHI").cross(1).move(16).commit();
-      design = design.strand(0, 40).move(10).commit();
-      design = design.strand(0, 50).move(-10).with_domain_name("JKL").commit();
+      design = design.draw_strand(1, 16).move(-16).cross(0).move(32).loopout(1, 3).move(-16).with_domain_name("DEF*").as_scaffold().commit();
+      design = design.draw_strand(1, 0).move(16).with_domain_name("ABC").cross(0).move(-16).commit();
+      design = design.draw_strand(0, 32).move(-16).with_domain_name("GHI").cross(1).move(16).commit();
+      design = design.draw_strand(0, 40).move(10).commit();
+      design = design.draw_strand(0, 50).move(-10).with_domain_name("JKL").commit();
     });
 
     /* 0              16               32      40       50  
@@ -226,10 +226,10 @@ main() {
       helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0, 0).move(8).with_domain_name("ABC").cross(0).move(-8).cross(0).as_circular().commit();
-      design = design.strand(0, 8).move(8).cross(0).move(-8).with_domain_name("DEF").commit();
-      design = design.strand(0, 24).move(-8).with_domain_name("GHI").cross(0).move(8).commit();
-      design = design.strand(0, 25).move(8).cross(0, 29).move(-3).with_domain_name("JKL*").cross(0,25).as_circular().commit();
+      design = design.draw_strand(0, 0).move(8).with_domain_name("ABC").cross(0).move(-8).cross(0).as_circular().commit();
+      design = design.draw_strand(0, 8).move(8).cross(0).move(-8).with_domain_name("DEF").commit();
+      design = design.draw_strand(0, 24).move(-8).with_domain_name("GHI").cross(0).move(8).commit();
+      design = design.draw_strand(0, 25).move(8).cross(0, 29).move(-3).with_domain_name("JKL*").cross(0,25).as_circular().commit();
     });
 
     /* 0       8       16      24      32
@@ -316,7 +316,7 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
       
-      design = design.strand(0, 0).move(8).with_domain_name("ABC").cross(0).move(-8).with_domain_name("XYZ").commit();
+      design = design.draw_strand(0, 0).move(8).with_domain_name("ABC").cross(0).move(-8).with_domain_name("XYZ").commit();
       
       var action = actions.AssignDomainNameComplementFromBoundStrands(design.strands);
       var state = app_state_from_design(design);
@@ -339,7 +339,7 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
       
-      design = design.strand(0, 0).move(9).with_domain_name("ABC").cross(0).move(-8).with_domain_name("XYZ").commit();
+      design = design.draw_strand(0, 0).move(9).with_domain_name("ABC").cross(0).move(-8).with_domain_name("XYZ").commit();
       
       var action = actions.AssignDomainNameComplementFromBoundStrands(design.strands);
       var state = app_state_from_design(design);
@@ -362,7 +362,7 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
       
-      design = design.strand(0, 0).move(8).cross(0).move(-8).commit();
+      design = design.draw_strand(0, 0).move(8).cross(0).move(-8).commit();
       
       var action = actions.AssignDomainNameComplementFromBoundStrands(design.strands);
       var state = app_state_from_design(design);
@@ -385,8 +385,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
       
-      design = design.strand(0, 0).move(8).with_domain_name("ABC").commit();
-      design = design.strand(0, 8).move(-8).with_domain_name("XYZ").commit();
+      design = design.draw_strand(0, 0).move(8).with_domain_name("ABC").commit();
+      design = design.draw_strand(0, 8).move(-8).with_domain_name("XYZ").commit();
       
       var action = actions.AssignDomainNameComplementFromBoundStrands(design.strands);
       var state = app_state_from_design(design);
@@ -409,8 +409,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
       
-      design = design.strand(0, 0).move(9).with_domain_name("ABC").commit();
-      design = design.strand(0, 8).move(-8).with_domain_name("XYZ").commit();
+      design = design.draw_strand(0, 0).move(9).with_domain_name("ABC").commit();
+      design = design.draw_strand(0, 8).move(-8).with_domain_name("XYZ").commit();
       
       var action = actions.AssignDomainNameComplementFromBoundStrands(design.strands);
       var state = app_state_from_design(design);
@@ -432,8 +432,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
       
-      design = design.strand(0, 0).move(8).commit();
-      design = design.strand(0, 8).move(-8).commit();
+      design = design.draw_strand(0, 0).move(8).commit();
+      design = design.draw_strand(0, 8).move(-8).commit();
       
       var action = actions.AssignDomainNameComplementFromBoundStrands(design.strands);
       var state = app_state_from_design(design);
@@ -455,8 +455,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
       
-      design = design.strand(0, 0).move(8).commit();
-      design = design.strand(0, 8).move(-8).commit();
+      design = design.draw_strand(0, 0).move(8).commit();
+      design = design.draw_strand(0, 8).move(-8).commit();
       
       var action = actions.AssignDomainNameComplementFromBoundStrands(design.strands);
       var state = app_state_from_design(design);
@@ -482,8 +482,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
       
-      design = design.strand(0, 0).move(8).with_domain_name("ABC").commit();
-      design = design.strand(0, 8).move(-8).with_domain_name("XYZ").commit();
+      design = design.draw_strand(0, 0).move(8).with_domain_name("ABC").commit();
+      design = design.draw_strand(0, 8).move(-8).with_domain_name("XYZ").commit();
       
       var action = actions.AssignDomainNameComplementFromBoundStrands([design.strands[0]]);
       var state = app_state_from_design(design);
@@ -506,8 +506,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
       
-      design = design.strand(0, 0).move(9).with_domain_name("ABC").commit();
-      design = design.strand(0, 8).move(-8).with_domain_name("XYZ").commit();
+      design = design.draw_strand(0, 0).move(9).with_domain_name("ABC").commit();
+      design = design.draw_strand(0, 8).move(-8).with_domain_name("XYZ").commit();
       
       var action = actions.AssignDomainNameComplementFromBoundStrands([design.strands[0]]);
       var state = app_state_from_design(design);
@@ -530,8 +530,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
       
-      design = design.strand(0, 0).move(8).commit();
-      design = design.strand(0, 8).move(-8).commit();
+      design = design.draw_strand(0, 0).move(8).commit();
+      design = design.draw_strand(0, 8).move(-8).commit();
       
       var action = actions.AssignDomainNameComplementFromBoundStrands([design.strands[0]]);
       var state = app_state_from_design(design);
@@ -554,8 +554,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
       
-      design = design.strand(0, 0).move(9).commit();
-      design = design.strand(0, 8).move(-8).commit();
+      design = design.draw_strand(0, 0).move(9).commit();
+      design = design.draw_strand(0, 8).move(-8).commit();
       
       var action = actions.AssignDomainNameComplementFromBoundStrands([design.strands[0]]);
       var state = app_state_from_design(design);
@@ -591,10 +591,10 @@ main() {
       ];
       design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(1, 16).move(-16).cross(0).move(32).loopout(1, 3).move(-16).with_domain_name("DEF*").as_scaffold().commit();
-      design = design.strand(1, 0).move(16).with_domain_name("ABC").cross(0).move(-16).commit();
-      design = design.strand(0, 32).move(-16).with_domain_name("GHI").cross(1).move(16).commit();
-      design = design.strand(0, 40).move(10).cross(0).move(-10).with_domain_name("JKL").as_circular().commit();
+      design = design.draw_strand(1, 16).move(-16).cross(0).move(32).loopout(1, 3).move(-16).with_domain_name("DEF*").as_scaffold().commit();
+      design = design.draw_strand(1, 0).move(16).with_domain_name("ABC").cross(0).move(-16).commit();
+      design = design.draw_strand(0, 32).move(-16).with_domain_name("GHI").cross(1).move(16).commit();
+      design = design.draw_strand(0, 40).move(10).cross(0).move(-10).with_domain_name("JKL").as_circular().commit();
 
       var all_overlapping_strands = design.strands_overlapping;
       
@@ -621,8 +621,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
       
-      design = design.strand(0, 0).move(9).commit();
-      design = design.strand(0, 8).move(-8).commit();
+      design = design.draw_strand(0, 0).move(9).commit();
+      design = design.draw_strand(0, 8).move(-8).commit();
 
       var all_overlapping_strands = design.strands_overlapping;
       
@@ -642,7 +642,7 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
       
-      design = design.strand(0, 0).move(8).cross(0, 6).move(-6).as_circular().commit();
+      design = design.draw_strand(0, 0).move(8).cross(0, 6).move(-6).as_circular().commit();
 
       var all_overlapping_strands = design.strands_overlapping;
       
@@ -659,8 +659,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
       
-      design = design.strand(0, 0).move(8).cross(0, 3).move(-3).as_circular().commit();
-      design = design.strand(0,8).move(-5).commit();
+      design = design.draw_strand(0, 0).move(8).cross(0, 3).move(-3).as_circular().commit();
+      design = design.draw_strand(0,8).move(-5).commit();
 
       var all_overlapping_strands = design.strands_overlapping;
       

--- a/test/assign_strand_name_unit_test.dart
+++ b/test/assign_strand_name_unit_test.dart
@@ -33,8 +33,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 16, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0,0).move(8).with_name("Scaf").as_scaffold().commit();
-      design = design.strand(0,8).move(4).with_name("NotScaf").commit();
+      design = design.draw_strand(0,0).move(8).with_name("Scaf").as_scaffold().commit();
+      design = design.draw_strand(0,8).move(4).with_name("NotScaf").commit();
 
             
       expect(design.strands[0].name, "Scaf");
@@ -52,8 +52,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 16, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0,0).move(8).with_name("Scaf").as_scaffold().commit();
-      design = design.strand(0,8).move(4).commit();
+      design = design.draw_strand(0,0).move(8).with_name("Scaf").as_scaffold().commit();
+      design = design.draw_strand(0,8).move(4).commit();
 
             
       expect(design.strands[0].name, "Scaf");
@@ -73,8 +73,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 20, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0,0).move(8).with_name("ABC").commit();
-      design = design.strand(0,8).move(8).with_name("XYZ").commit();
+      design = design.draw_strand(0,0).move(8).with_name("ABC").commit();
+      design = design.draw_strand(0,8).move(8).with_name("XYZ").commit();
 
       var action = actions.Ligate(dna_end: design.strands[0].dnaend_3p);
       var state = app_state_from_design(design);
@@ -87,8 +87,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 20, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0,0).move(8).with_name("ABC").commit();
-      design = design.strand(0,8).move(8).with_name("XYZ").commit();
+      design = design.draw_strand(0,0).move(8).with_name("ABC").commit();
+      design = design.draw_strand(0,8).move(8).with_name("XYZ").commit();
 
       var action = actions.Ligate(dna_end: design.strands[1].dnaend_5p);
       var state = app_state_from_design(design);
@@ -101,8 +101,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 20, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0,0).move(8).with_name("ABC").commit();
-      design = design.strand(0,8).move(-8).with_name("XYZ").commit();
+      design = design.draw_strand(0,0).move(8).with_name("ABC").commit();
+      design = design.draw_strand(0,8).move(-8).with_name("XYZ").commit();
 
       var action = 
           actions.JoinStrandsByCrossover(dna_end_first_click: design.strands[0].dnaend_3p, dna_end_second_click: design.strands[1].dnaend_5p);
@@ -116,8 +116,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 20, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0,0).move(8).with_name("ABC").commit();
-      design = design.strand(0,8).move(-8).with_name("XYZ").commit();
+      design = design.draw_strand(0,0).move(8).with_name("ABC").commit();
+      design = design.draw_strand(0,8).move(-8).with_name("XYZ").commit();
 
       var action = 
           actions.JoinStrandsByCrossover(dna_end_first_click: design.strands[1].dnaend_3p, dna_end_second_click: design.strands[0].dnaend_5p);
@@ -131,8 +131,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 20, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0,0).move(8).with_name("ABC").as_scaffold().commit();
-      design = design.strand(0,8).move(8).with_name("XYZ").as_scaffold().commit();
+      design = design.draw_strand(0,0).move(8).with_name("ABC").as_scaffold().commit();
+      design = design.draw_strand(0,8).move(8).with_name("XYZ").as_scaffold().commit();
 
       var action = actions.Ligate(dna_end: design.strands[0].dnaend_3p);
       var state = app_state_from_design(design);
@@ -145,8 +145,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 20, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0,0).move(8).with_name("ABC").as_scaffold().commit();
-      design = design.strand(0,8).move(8).with_name("XYZ").as_scaffold().commit();
+      design = design.draw_strand(0,0).move(8).with_name("ABC").as_scaffold().commit();
+      design = design.draw_strand(0,8).move(8).with_name("XYZ").as_scaffold().commit();
 
       var action = actions.Ligate(dna_end: design.strands[1].dnaend_5p);
       var state = app_state_from_design(design);
@@ -159,8 +159,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 20, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0,0).move(8).with_name("ABC").as_scaffold().commit();
-      design = design.strand(0,8).move(-8).with_name("XYZ").as_scaffold().commit();
+      design = design.draw_strand(0,0).move(8).with_name("ABC").as_scaffold().commit();
+      design = design.draw_strand(0,8).move(-8).with_name("XYZ").as_scaffold().commit();
 
       var action = 
           actions.JoinStrandsByCrossover(dna_end_first_click: design.strands[0].dnaend_3p, dna_end_second_click: design.strands[1].dnaend_5p);
@@ -174,8 +174,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 20, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0,0).move(8).with_name("ABC").as_scaffold().commit();
-      design = design.strand(0,8).move(-8).with_name("XYZ").as_scaffold().commit();
+      design = design.draw_strand(0,0).move(8).with_name("ABC").as_scaffold().commit();
+      design = design.draw_strand(0,8).move(-8).with_name("XYZ").as_scaffold().commit();
 
       var action = 
           actions.JoinStrandsByCrossover(dna_end_first_click: design.strands[1].dnaend_3p, dna_end_second_click: design.strands[0].dnaend_5p);
@@ -190,8 +190,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 16, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0,0).move(8).with_name("ABC").commit();
-      design = design.strand(0,8).move(4).commit();
+      design = design.draw_strand(0,0).move(8).with_name("ABC").commit();
+      design = design.draw_strand(0,8).move(4).commit();
 
             
       expect(design.strands[0].name, "ABC");
@@ -210,8 +210,8 @@ main() {
       var helices = [Helix(idx: 0, max_offset: 16, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
 
-      design = design.strand(0,0).move(8).with_name("XYZ").commit();
-      design = design.strand(0,8).move(-8).commit();
+      design = design.draw_strand(0,0).move(8).with_name("XYZ").commit();
+      design = design.draw_strand(0,8).move(-8).commit();
 
       expect(design.strands[0].name, "XYZ");
       expect(design.strands[1].name, null);

--- a/test/circular_strands_unit_test.dart
+++ b/test/circular_strands_unit_test.dart
@@ -73,12 +73,12 @@ main() {
     setUp(() {
       helices = [for (int i = 0; i < 3; i++) Helix(idx: i, max_offset: 100, grid: Grid.square)];
       design = Design(helices: helices, grid: Grid.square);
-      design = design.strand(0, 0).move(10).cross(1).move(-10).commit();
-      design = design.strand(0, 15).move(5).cross(1).move(-10).cross(0).move(5).commit();
-      design = design.strand(0, 20).move(10).commit();
-      design = design.strand(1, 30).move(-10).commit();
-      design = design.strand(0, 30).move(10).loopout(1, 5).move(-10).cross(2).move(10).as_circular().commit();
-      design = design.strand(0, 40).move(10).cross(1).move(-10).as_circular().commit();
+      design = design.draw_strand(0, 0).move(10).cross(1).move(-10).commit();
+      design = design.draw_strand(0, 15).move(5).cross(1).move(-10).cross(0).move(5).commit();
+      design = design.draw_strand(0, 20).move(10).commit();
+      design = design.draw_strand(1, 30).move(-10).commit();
+      design = design.draw_strand(0, 30).move(10).loopout(1, 5).move(-10).cross(2).move(10).as_circular().commit();
+      design = design.draw_strand(0, 40).move(10).cross(1).move(-10).as_circular().commit();
       num_strands = design.strands.length;
     });
     /*
@@ -1035,7 +1035,7 @@ main() {
       */
       helices = [for (int i = 0; i < 2; i++) Helix(idx: i, max_offset: 100, grid: Grid.square)];
       design = Design(helices: helices, grid: Grid.square);
-      design = design.strand(0, 5).move(5).loopout(1, 5).move(-10).cross(0).move(5).commit();
+      design = design.draw_strand(0, 5).move(5).loopout(1, 5).move(-10).cross(0).move(5).commit();
       num_strands = design.strands.length;
 
       // expectations before change
@@ -1088,7 +1088,7 @@ main() {
       */
       helices = [for (int i = 0; i < 2; i++) Helix(idx: i, max_offset: 100, grid: Grid.square)];
       design = Design(helices: helices, grid: Grid.square);
-      design = design.strand(1, 5).move(-5).cross(0).move(10).loopout(1, 5).move(-5).commit();
+      design = design.draw_strand(1, 5).move(-5).cross(0).move(10).loopout(1, 5).move(-5).commit();
       num_strands = design.strands.length;
 
       // expectations before change

--- a/test/domain_label_move_test.dart
+++ b/test/domain_label_move_test.dart
@@ -49,7 +49,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(8)
           .with_domain_name("ABC")
           .cross(1)
@@ -124,7 +124,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(8)
           .with_domain_name("ABC")
           .loopout(1, 2)
@@ -198,7 +198,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(8)
           .with_domain_name("ABC")
           .cross(1)
@@ -273,7 +273,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(8)
           .with_domain_name("ABC")
           .loopout(1, 2)
@@ -344,7 +344,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(8)
           .with_domain_name("ABC")
           .cross(1)

--- a/test/export_cadnano_v2_test.dart
+++ b/test/export_cadnano_v2_test.dart
@@ -90,7 +90,7 @@ main() {
     test('test_2_staple_2_helix_origami_extremely_simple', () {
       List<Helix> helices = [Helix(idx: 0, max_offset: 32, grid: Grid.square), Helix(idx: 1, max_offset: 32, grid: Grid.square)];
       Design design = Design(helices:helices, grid:Grid.square);
-      design = design.strand(0, 0).move(32).as_scaffold().commit();
+      design = design.draw_strand(0, 0).move(32).as_scaffold().commit();
 
       String output_json = to_cadnano_v2_json(design);
       Design output_design = Design.from_cadnano_v2_json_str(output_json);
@@ -99,7 +99,7 @@ main() {
     test('test_2_staple_2_helix_origami_extremely_simple_2', () {
       List<Helix> helices = [Helix(idx: 0, max_offset: 32, grid: Grid.square), Helix(idx: 1, max_offset: 32, grid: Grid.square)];
       Design design = Design(helices:helices, grid:Grid.square);
-      design = design.strand(0, 0).move(32).cross(1).move(-32).as_scaffold().commit();
+      design = design.draw_strand(0, 0).move(32).cross(1).move(-32).as_scaffold().commit();
 
       String output_json = to_cadnano_v2_json(design);
       Design output_design = Design.from_cadnano_v2_json_str(output_json);
@@ -114,13 +114,13 @@ main() {
       Design design = Design(helices: helices, grid: Grid.square);
 
       // left staple
-      design = design.strand(1, 0).move(16).cross(0).move(-16).commit();
+      design = design.draw_strand(1, 0).move(16).cross(0).move(-16).commit();
 
       // right staple
-      design = design.strand(0, 32).move(-16).cross(1).move(16).commit();
+      design = design.draw_strand(0, 32).move(-16).cross(1).move(16).commit();
 
       // scaffold
-      design = design.strand(1, 16)
+      design = design.draw_strand(1, 16)
         .move(-16)
         .cross(0)
         .move(32)
@@ -209,7 +209,7 @@ main() {
       ];
       Design design = Design(helices: helices, grid: Grid.square);
 
-      design.strand(1,0).move(8).cross(0).move(-8).as_circular().commit();
+      design.draw_strand(1,0).move(8).cross(0).move(-8).as_circular().commit();
       String output_json = to_cadnano_v2_json(design);
       Design output_design = Design.from_cadnano_v2_json_str(output_json);
       expect(output_design.helices.length, 2);
@@ -251,7 +251,7 @@ main() {
         Helix(idx: 1, max_offset: 32, grid: Grid.square),
       ];
       Design design = Design(helices: helices, grid: Grid.square);
-      design = design.strand(1, 0).move(32).as_scaffold().commit();
+      design = design.draw_strand(1, 0).move(32).as_scaffold().commit();
 
       try {
         to_cadnano_v2_json(design);
@@ -271,13 +271,13 @@ main() {
       Design design = Design(helices: helices, grid: Grid.square);
 
       // left staple
-      design = design.strand(1, 8).move(16).cross(0).move(-16).commit();
+      design = design.draw_strand(1, 8).move(16).cross(0).move(-16).commit();
 
       // right staple
-      design = design.strand(0, 40).move(-16).cross(1).move(16).commit();
+      design = design.draw_strand(0, 40).move(-16).cross(1).move(16).commit();
 
       // scaffold
-      design = design.strand(1, 24)
+      design = design.draw_strand(1, 24)
         .move(-16)
         .cross(0)
         .move(32)

--- a/test/helix_rotation_set_test.dart
+++ b/test/helix_rotation_set_test.dart
@@ -45,7 +45,7 @@ main() {
     //  2  <----+
     setUp(() async {
       var pre_design_vert = Design(grid: Grid.square, num_helices: 3);
-      design_vert = pre_design_vert.strand(0, 5).to(0).cross(1).to(5).cross(2).to(0).commit();
+      design_vert = pre_design_vert.draw_strand(0, 5).to(0).cross(1).to(5).cross(2).to(0).commit();
       state_vert = app_state_from_design(design_vert);
     });
 
@@ -141,7 +141,7 @@ main() {
         Helix(idx: 2, grid: Grid.square, geometry: geometry, grid_position: GridPosition(2, 0)),
       ];
       var pre_design_horz = Design(grid: Grid.square, helices: helices);
-      design_horz = pre_design_horz.strand(0, 5).to(0).cross(1).to(5).cross(2).to(0).commit();
+      design_horz = pre_design_horz.draw_strand(0, 5).to(0).cross(1).to(5).cross(2).to(0).commit();
       state_horz = app_state_from_design(design_horz);
     });
 
@@ -247,8 +247,8 @@ main() {
             roll: 0),
       ];
       design = Design(grid: Grid.none, helices: helices, geometry: geometry);
-      design = design.strand(1, 5).to(0).cross(0).to(5).commit();
-      design = design.strand(2, 5).to(0).cross(1).to(5).commit();
+      design = design.draw_strand(1, 5).to(0).cross(0).to(5).commit();
+      design = design.draw_strand(2, 5).to(0).cross(1).to(5).commit();
       state = app_state_from_design(design);
     });
 

--- a/test/idt_unit_test.dart
+++ b/test/idt_unit_test.dart
@@ -73,33 +73,33 @@ col major top-left domain start: ABCDEFLHJGIKMNOPQR
   var helices = [for (int i = 0; i < 6; i++) Helix(idx: i, max_offset: 100, grid: Grid.square)];
   var d = Design(helices: helices, grid: Grid.square);
 
-  d = d.strand(1, 0).move(16).cross(0).move(-16).with_name('A').commit();
-  d = d.strand(3, 0).move(16).cross(2).move(-16).with_name('B').commit();
-  d = d.strand(5, 0).move(16).cross(4).move(-16).with_name('C').commit();
+  d = d.draw_strand(1, 0).move(16).cross(0).move(-16).with_name('A').commit();
+  d = d.draw_strand(3, 0).move(16).cross(2).move(-16).with_name('B').commit();
+  d = d.draw_strand(5, 0).move(16).cross(4).move(-16).with_name('C').commit();
 
-  d = d.strand(0, 40).move(-24).cross(1).move(8).with_name('D').commit();
+  d = d.draw_strand(0, 40).move(-24).cross(1).move(8).with_name('D').commit();
 
-  d = d.strand(1, 24).move(8).cross(2).move(-16).cross(3).move(8).with_name('E').commit();
-  d = d.strand(3, 24).move(8).cross(4).move(-16).cross(5).move(8).with_name('F').commit();
+  d = d.draw_strand(1, 24).move(8).cross(2).move(-16).cross(3).move(8).with_name('E').commit();
+  d = d.draw_strand(3, 24).move(8).cross(4).move(-16).cross(5).move(8).with_name('F').commit();
 
-  d = d.strand(0, 72).move(-32).with_name('G').commit();
+  d = d.draw_strand(0, 72).move(-32).with_name('G').commit();
 
-  d = d.strand(2, 40).move(-8).cross(1).move(24).with_name('H').commit();
-  d = d.strand(1, 56).move(8).cross(2).move(-24).with_name('I').commit();
+  d = d.draw_strand(2, 40).move(-8).cross(1).move(24).with_name('H').commit();
+  d = d.draw_strand(1, 56).move(8).cross(2).move(-24).with_name('I').commit();
 
-  d = d.strand(4, 40).move(-8).cross(3).move(24).with_name('J').commit();
-  d = d.strand(3, 56).move(8).cross(4).move(-24).with_name('K').commit();
+  d = d.draw_strand(4, 40).move(-8).cross(3).move(24).with_name('J').commit();
+  d = d.draw_strand(3, 56).move(8).cross(4).move(-24).with_name('K').commit();
 
-  d = d.strand(5, 24).move(32).with_name('L').commit();
+  d = d.draw_strand(5, 24).move(32).with_name('L').commit();
 
-  d = d.strand(2, 72).move(-8).cross(1).move(16).cross(0).move(-8).with_name('M').commit();
-  d = d.strand(4, 72).move(-8).cross(3).move(16).cross(2).move(-8).with_name('N').commit();
+  d = d.draw_strand(2, 72).move(-8).cross(1).move(16).cross(0).move(-8).with_name('M').commit();
+  d = d.draw_strand(4, 72).move(-8).cross(3).move(16).cross(2).move(-8).with_name('N').commit();
 
-  d = d.strand(5, 56).move(24).cross(4).move(-8).with_name('O').commit();
+  d = d.draw_strand(5, 56).move(24).cross(4).move(-8).with_name('O').commit();
 
-  d = d.strand(0, 96).move(-16).cross(1).move(16).with_name('P').commit();
-  d = d.strand(2, 96).move(-16).cross(3).move(16).with_name('Q').commit();
-  d = d.strand(4, 96).move(-16).cross(5).move(16).with_name('R').commit();
+  d = d.draw_strand(0, 96).move(-16).cross(1).move(16).with_name('P').commit();
+  d = d.draw_strand(2, 96).move(-16).cross(3).move(16).with_name('Q').commit();
+  d = d.draw_strand(4, 96).move(-16).cross(5).move(16).with_name('R').commit();
 
   // assign DNA to strands so we can export IDT
   var strands = d.strands.toList();

--- a/test/inline_insertions_deletions_test.dart
+++ b/test/inline_insertions_deletions_test.dart
@@ -1,0 +1,321 @@
+// @dart=2.9
+
+import 'dart:convert';
+
+import 'package:scadnano/src/json_serializable.dart';
+import 'package:scadnano/src/reducers/change_loopout_length.dart';
+import 'package:scadnano/src/reducers/delete_reducer.dart';
+import 'package:scadnano/src/reducers/inline_insertions_deletions_reducer.dart';
+import 'package:scadnano/src/reducers/nick_ligate_join_by_crossover_reducers.dart';
+import 'package:scadnano/src/reducers/assign_domain_names_reducer.dart';
+import 'package:scadnano/src/state/domain.dart';
+import 'package:scadnano/src/state/grid_position.dart';
+import 'package:scadnano/src/state/helix.dart';
+import 'package:scadnano/src/state/grid.dart';
+import 'package:scadnano/src/state/loopout.dart';
+import 'package:scadnano/src/state/select_mode.dart';
+import 'package:test/test.dart';
+
+import 'package:scadnano/src/state/design.dart';
+import 'package:scadnano/src/actions/actions.dart' as actions;
+
+import 'utils.dart';
+
+void helix0_strand0_inlined_test(
+    Design design, {int max_offset, List<int> major_ticks, int start, int end}) {
+  expect(design.helices.length, 1);
+  expect(design.strands.length, 1);
+  var helix = design.helices[0];
+  var strand = design.strands[0];
+  expect(helix.max_offset, max_offset);
+  expect(helix.major_ticks, major_ticks);
+  expect(strand.domains[0].start, start);
+  expect(strand.domains[0].end, end);
+  expect(strand.domains[0].deletions, []);
+  expect(strand.domains[0].insertions, []);
+}
+
+main() {
+  group('InlineInsertionsDeletions', () {
+    Design design;
+    actions.InlineInsertionsDeletions action = actions.InlineInsertionsDeletions();
+
+    setUp(() async {
+      design = Design(helices: [
+        Helix(max_offset: 24, grid_position: GridPosition(0, 0), major_tick_periodic_distances: [8], idx: 0)
+      ], strands: [], grid: Grid.square);
+    });
+
+    test('no_deletion_after_loopout', () {
+      expect(() => design.draw_strand(0, 0).move(8).loopout(0, 10, 5).with_deletion(4),
+          throwsArgumentError);
+    });
+
+    test('no_insertion_after_loopout', () {
+      expect(() => design.draw_strand(0, 0).move(8).loopout(0, 10, 5).with_insertion(4, 2),
+          throwsArgumentError);
+    });
+
+    test('deletion_below_range', () {
+      expect(() => design.draw_strand(0, 4).move(4).with_deletion(2),
+          throwsA(IllegalDesignError('')));
+    });
+
+    test('deletion_above_range', () {
+      expect(() => design.draw_strand(0, 0).move(4).with_deletion(6),
+          throwsA(IllegalDesignError('')));
+    });
+
+    test('insertion_below_range', () {
+      expect(() => design.draw_strand(0, 4).move(4).with_insertion(2, 2),
+          throwsA(IllegalDesignError('')));
+    });
+
+    test('insertion_above_range', () {
+      expect(() => design.draw_strand(0, 0).move(4).with_insertion(6, 2),
+          throwsA(IllegalDesignError('')));
+    });
+
+    test('inline_deletions_insertions__one_deletion', () {
+      /*
+        before
+        0   4   8       16      24
+        |       |       |       |
+    0   [---X-->
+
+        after
+        0   4  7       15      23
+        |      |       |       |
+    0   [----->
+        */
+      design = design.draw_strand(0, 0).move(8).with_deletion(4).commit();
+      design = inline_insertions_deletions_reducer(design, action);
+      helix0_strand0_inlined_test(design, max_offset: 23, major_ticks: [0, 7, 15, 23], start: 0, end: 7);
+    });
+
+    test('inline_deletions_insertions__two_deletions', () {
+      /*
+        before
+        0 2 4   8       16      24
+        |       |       |       |
+    0   [-X-X-->
+
+        after
+        0     6       14      22
+        |     |       |       |
+    0   [---->
+        */
+      design = design.draw_strand(0, 0).move(8).with_deletions([2, 4]).commit();
+      design = inline_insertions_deletions_reducer(design, action);
+      helix0_strand0_inlined_test(design, max_offset: 22, major_ticks: [0, 6, 14, 22], start: 0, end: 6);
+    });
+
+    test('inline_deletions_insertions__one_insertion', () {
+      /*
+        before
+        0   4   8       16      24
+        |       |       |       |
+    0   [---1-->
+
+        after
+        0        9       17      25
+        |        |       |       |
+    0   [------->
+        */
+      design = design.draw_strand(0, 0).move(8).with_insertion(4, 1).commit();
+      design = inline_insertions_deletions_reducer(design, action);
+      helix0_strand0_inlined_test(design, max_offset: 25, major_ticks: [0, 9, 17, 25], start: 0, end: 9);
+    });
+
+    test('inline_deletions_insertions__two_insertions', () {
+      /*
+        before
+        0 2 4   8       16      24
+        |       |       |       |
+    0   [-3-1-->
+
+        after
+        0           12      20      28
+        |           |       |       |
+    0   [---------->
+        */
+      design = design.draw_strand(0, 0).move(8).with_insertions([Insertion(2, 3), Insertion(4, 1)]).commit();
+      design = inline_insertions_deletions_reducer(design, action);
+      helix0_strand0_inlined_test(design, max_offset: 28, major_ticks: [0, 12, 20, 28], start: 0, end: 12);
+    });
+
+    test('inline_deletions_insertions__one_deletion_one_insertion', () {
+      /*
+        before
+        0 2 4   8       16      24
+        |       |       |       |
+    0   [-3-X-->
+
+        after
+        0         10      18      26
+        |         |       |       |
+    0   [-------->
+        */
+      design = design.draw_strand(0, 0).move(8).with_deletion(4).with_insertion(2, 3).commit();
+      design = inline_insertions_deletions_reducer(design, action);
+      helix0_strand0_inlined_test(design, max_offset: 26, major_ticks: [0, 10, 18, 26], start: 0, end: 10);
+    });
+
+    test('inline_deletions_insertions__one_deletion_right_of_major_tick', () {
+      /*
+        before
+        0       89      16      24
+        |       |       |       |
+    0   [--------X->
+
+        after
+        0       8      15      23
+        |       |      |       |
+    0   [--------->
+        */
+      design = design.draw_strand(0, 0).move(12).with_deletion(9).commit();
+      design = inline_insertions_deletions_reducer(design, action);
+      helix0_strand0_inlined_test(design, max_offset: 23, major_ticks: [0, 8, 15, 23], start: 0, end: 11);
+    });
+
+    test('inline_deletions_insertions__one_deletion_on_major_tick', () {
+      /*
+        | is major tick, and . is minor tick
+        before
+         0               8               16              24
+        | . . . . . . . | . . . . . . . | . . . . . . . |
+         [ - - - - - - - X - - >
+
+        after
+         0               8             15              23
+        | . . . . . . . | . . . . . . | . . . . . . . |
+         [ - - - - - - - - - >
+        */
+      design = design.draw_strand(0, 0).move(12).with_deletion(8).commit();
+      design = inline_insertions_deletions_reducer(design, action);
+      helix0_strand0_inlined_test(design, max_offset: 23, major_ticks: [0, 8, 15, 23], start: 0, end: 11);
+    });
+
+    test('inline_deletions_insertions__one_deletion_left_of_major_tick', () {
+      /*
+        before
+        0      78       16      24
+        |       |       |       |
+    0   [------X--->
+
+        after
+        0       8      15      23
+        |       |      |       |
+    0   [--------->
+        */
+      design = design.draw_strand(0, 0).move(12).with_deletion(7).commit();
+      design = inline_insertions_deletions_reducer(design, action);
+      helix0_strand0_inlined_test(design, max_offset: 23, major_ticks: [0, 7, 15, 23], start: 0, end: 11);
+    });
+
+    test('inline_deletions_insertions__one_insertion_right_of_major_tick', () {
+      /*
+        before
+        0       89      16      24
+        |       |       |       |
+    0   [--------1->
+
+        after
+        0       8        17      25
+        |       |        |       |
+    0   [----------->
+        */
+      design = design.draw_strand(0, 0).move(12).with_insertion(9, 1).commit();
+      design = inline_insertions_deletions_reducer(design, action);
+      helix0_strand0_inlined_test(design, max_offset: 25, major_ticks: [0, 8, 17, 25], start: 0, end: 13);
+    });
+
+    test('inline_deletions_insertions__one_insertion_on_major_tick', () {
+      /*
+        before
+        0       8       16      24
+        |       |       |       |
+    0   [-------1-->
+
+        after
+        0       8        17      25
+        |       |        |       |
+    0   [----------->
+        */
+      design = design.draw_strand(0, 0).move(12).with_insertion(8, 1).commit();
+      design = inline_insertions_deletions_reducer(design, action);
+      helix0_strand0_inlined_test(design, max_offset: 25, major_ticks: [0, 8, 17, 25], start: 0, end: 13);
+    });
+
+    test('inline_deletions_insertions__one_insertion_left_of_major_tick', () {
+      /*
+        before
+        0      78       16      24
+        |       |       |       |
+    0   [------1--->
+
+        after
+        0        9       17      25
+        |        |       |       |
+    0   [----------->
+        */
+      design = design.draw_strand(0, 0).move(12).with_insertion(7, 1).commit();
+      design = inline_insertions_deletions_reducer(design, action);
+      helix0_strand0_inlined_test(design, max_offset: 25, major_ticks: [0, 9, 17, 25], start: 0, end: 13);
+    });
+
+    test('inline_deletions_insertions__deletions_insertions_in_multiple_domains', () {
+      /*
+        before
+        0    5  8  11   16 19   24
+        |       |       |       |
+    0   [----2-----1-------X---->
+
+        after
+        0         10      19      26
+        |         |       |       |
+    0   [------------------------->
+        */
+      design = design.draw_strand(0, 0).move(24).with_deletion(19).with_insertions([
+        Insertion(5, 2), Insertion(11, 1)]).commit();
+      design = inline_insertions_deletions_reducer(design, action);
+      helix0_strand0_inlined_test(design, max_offset: 26, major_ticks: [0, 10, 19, 26], start: 0, end: 26);
+    });
+
+
+    test('inline_deletions_insertions__deletions_insertions_in_multiple_domains_two_strands', () {
+      /*
+        | is major tick, . is minor tick
+        before
+         0   2     5     8   10          16    19        24
+        | . . . . . . . | . . . . . . . | . . . . . . . |
+         [ - X - - 2 - - - - 1 - - > [ - - - - X - - - >
+
+        after
+         0   2     5       9             16  18            25
+        | . . . . . . . . | . . . . . . . . | . . . . . . |
+         [ - - - - - - - - - - - - - - > [ - - - - - - - >
+        */
+      design = design.draw_strand(0, 0).move(14).with_deletion(2).with_insertions([
+        Insertion(5, 2), Insertion(10, 1)]).commit();
+      design = design.draw_strand(0, 14).to(24).with_deletion(19).commit();
+      design = inline_insertions_deletions_reducer(design, action);
+      expect(design.helices.length, 1);
+      expect(design.strands.length, 2);
+      var helix = design.helices[0];
+      var strand0 = design.strands[0];
+      var strand1 = design.strands[1];
+      expect(helix.max_offset, 25);
+      expect(helix.calculate_major_ticks, [0, 9, 18, 25]);
+      expect(strand0.domains[0].start, 0);
+      expect(strand0.domains[0].end, 16);
+      expect(strand1.domains[0].start, 16);
+      expect(strand1.domains[0].end, 25);
+      expect(strand0.domains[0].deletions, []);
+      expect(strand0.domains[0].insertions, []);
+      expect(strand1.domains[0].deletions, []);
+      expect(strand1.domains[0].insertions, []);
+    });
+
+  });
+}

--- a/test/join_strands_by_crossovers_test.dart
+++ b/test/join_strands_by_crossovers_test.dart
@@ -42,11 +42,11 @@ main() {
 
         if (helix == 0) {
           // top scaffold has no nick
-          design = design.strand(0, 0).to(right_end).as_scaffold().commit();
+          design = design.draw_strand(0, 0).to(right_end).as_scaffold().commit();
         } else {
-          design = design.strand(helix, scaffold_5p).move(scaffold_move).as_scaffold().commit();
+          design = design.draw_strand(helix, scaffold_5p).move(scaffold_move).as_scaffold().commit();
           design =
-              design.strand(helix, scaffold_5p + scaffold_move).move(scaffold_move).as_scaffold().commit();
+              design.draw_strand(helix, scaffold_5p + scaffold_move).move(scaffold_move).as_scaffold().commit();
         }
       }
 
@@ -60,7 +60,7 @@ main() {
         }
         int staple_offset = staple_5p;
         for (int i = 0; i < 4; i++) {
-          design = design.strand(helix, staple_offset).move(staple_move).commit();
+          design = design.draw_strand(helix, staple_offset).move(staple_move).commit();
           staple_offset += staple_move;
         }
       }

--- a/test/move_linker_test.dart
+++ b/test/move_linker_test.dart
@@ -53,7 +53,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(4)
           .cross(1)
           .move(-4)
@@ -61,7 +61,7 @@ main() {
           .move(4)
           .with_sequence('AAAACCCCGGGG')
           .commit();
-      design = design.strand(3, 0).move(4).with_sequence('TTTT').commit();
+      design = design.draw_strand(3, 0).move(4).with_sequence('TTTT').commit();
       AppState state = app_state_from_design(design);
       Strand strand1 = design.strands[0];
       Strand strand2 = design.strands[1];
@@ -135,7 +135,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(4)
           .cross(1)
           .move(-4)
@@ -143,7 +143,7 @@ main() {
           .move(4)
           .with_sequence('AAAACCCCGGGG')
           .commit();
-      design = design.strand(3, 0).move(4).with_sequence('TTTT').commit();
+      design = design.draw_strand(3, 0).move(4).with_sequence('TTTT').commit();
       AppState state = app_state_from_design(design);
       Strand strand1 = design.strands[0];
       Strand strand2 = design.strands[1];
@@ -216,7 +216,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(4)
           .loopout(1, 1)
           .move(-4)
@@ -224,7 +224,7 @@ main() {
           .move(4)
           .with_sequence('AAAAGCCCCTGGGG')
           .commit();
-      design = design.strand(3, 0).move(4).with_sequence('TTTT').commit();
+      design = design.draw_strand(3, 0).move(4).with_sequence('TTTT').commit();
       AppState state = app_state_from_design(design);
       Strand strand1 = design.strands[0];
       Strand strand2 = design.strands[1];
@@ -300,7 +300,7 @@ main() {
       var design = Design(helices: helices, grid: Grid.square);
 
       design = design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .move(4)
           .loopout(1, 1)
           .move(-4)
@@ -308,7 +308,7 @@ main() {
           .move(4)
           .with_sequence('AAAAGCCCCTGGGG')
           .commit();
-      design = design.strand(3, 0).move(4).with_sequence('TTTT').commit();
+      design = design.draw_strand(3, 0).move(4).with_sequence('TTTT').commit();
       AppState state = app_state_from_design(design);
       Strand strand1 = design.strands[0];
       Strand strand2 = design.strands[1];

--- a/test/other_unit_test.dart
+++ b/test/other_unit_test.dart
@@ -79,8 +79,8 @@ main() {
   test('duplicate_deletions_in_design_removed', () {
     var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square),Helix(idx: 1, max_offset: 100, grid: Grid.square) ];
     var design = Design(helices: helices, grid: Grid.square);
-    design = design.strand(0, 0).move(8).commit();
-    design = design.strand(1, 8).move(-8).add_deletion(1, 4).commit();
+    design = design.draw_strand(0, 0).move(8).commit();
+    design = design.draw_strand(1, 8).move(-8).add_deletion(1, 4).commit();
     var action = actions.DeletionAdd(domain: design.all_domains[0], offset: 4, all_helices: true);
     var new_domains = deletion_add_reducer(design.all_domains[0], action);
     expect(1, new_domains.deletions.length);
@@ -98,8 +98,8 @@ main() {
   test('duplicate_inseritons_in_design_removed', () {
     var helices = [Helix(idx: 0, max_offset: 100, grid: Grid.square),Helix(idx: 1, max_offset: 100, grid: Grid.square) ];
     var design = Design(helices: helices, grid: Grid.square);
-    design = design.strand(0, 0).move(8).commit();
-    design = design.strand(1, 8).move(-8).add_insertion(1, 4, 1).commit();
+    design = design.draw_strand(0, 0).move(8).commit();
+    design = design.draw_strand(1, 8).move(-8).add_insertion(1, 4, 1).commit();
     var action = actions.InsertionAdd(domain: design.all_domains[0], offset: 4, all_helices: true);
     var new_domains = insertion_add_reducer(design.all_domains[0], action);
     expect(1, new_domains.insertions.length);
@@ -243,7 +243,7 @@ main() {
     ];
     test('test_strand__0_0_to_10_cross_1_to_5', () {
       Design actual_design = new Design(grid: Grid.square, helices: helices);
-      actual_design = actual_design.strand(0, 0).to(10).cross(1).to(5).commit();
+      actual_design = actual_design.draw_strand(0, 0).to(10).cross(1).to(5).commit();
 
       Design expected_design = new Design(grid: Grid.square, helices: helices);
       expected_design = expected_design.rebuild((s) => s
@@ -255,7 +255,7 @@ main() {
     });
     test('test_strand__0_0_to_10_cross_1_to_5__reverse', () {
       Design actual_design = new Design(grid: Grid.square, helices: helices);
-      actual_design = actual_design.strand(1, 5).to(10).cross(0).to(0).commit();
+      actual_design = actual_design.draw_strand(1, 5).to(10).cross(0).to(0).commit();
 
       Design expected_design = new Design(grid: Grid.square, helices: helices);
       expected_design = expected_design.rebuild((s) => s
@@ -267,7 +267,7 @@ main() {
     });
     test('test_strand__h0_off0_to_off10_cross_h1_to_off5_loopout_length3_h2_to_off15', () {
       Design actual_design = new Design(grid: Grid.square, helices: helices);
-      actual_design = actual_design.strand(0, 0).to(10).cross(1).to(5).loopout(2, 3).to(15).commit();
+      actual_design = actual_design.draw_strand(0, 0).to(10).cross(1).to(5).loopout(2, 3).to(15).commit();
 
       Design expected_design = new Design(grid: Grid.square, helices: helices);
       expected_design = expected_design.rebuild((s) => s
@@ -281,7 +281,7 @@ main() {
     });
     test('test_strand__two_forward_paranemic_crossovers', () {
       Design actual_design = new Design(grid: Grid.square, helices: helices);
-      actual_design = actual_design.strand(0, 0).to(10).cross(1).to(15).cross(2).to(20).commit();
+      actual_design = actual_design.draw_strand(0, 0).to(10).cross(1).to(15).cross(2).to(20).commit();
 
       Design expected_design = new Design(grid: Grid.square, helices: helices);
       expected_design = expected_design.rebuild((s) => s
@@ -295,7 +295,7 @@ main() {
     });
     test('test_strand__two_reverse_paranemic_crossovers', () {
       Design actual_design = new Design(grid: Grid.square, helices: helices);
-      actual_design = actual_design.strand(0, 20).to(10).cross(1).to(5).cross(2).to(0).commit();
+      actual_design = actual_design.draw_strand(0, 20).to(10).cross(1).to(5).cross(2).to(0).commit();
 
       Design expected_design = new Design(grid: Grid.square, helices: helices);
       expected_design = expected_design.rebuild((s) => s
@@ -308,8 +308,8 @@ main() {
     });
     test('test_strand__multiple_strands', () {
       Design actual_design = new Design(grid: Grid.square, helices: helices);
-      actual_design = actual_design.strand(0, 0).to(10).cross(1).to(0).commit();
-      actual_design = actual_design.strand(0, 20).to(10).cross(1).to(20).commit();
+      actual_design = actual_design.draw_strand(0, 0).to(10).cross(1).to(0).commit();
+      actual_design = actual_design.draw_strand(0, 20).to(10).cross(1).to(20).commit();
 
       Design expected_design = new Design(grid: Grid.square, helices: helices);
       expected_design = expected_design.rebuild((s) => s
@@ -332,8 +332,8 @@ main() {
     });
     test('test_strand__multiple_strands_other_order', () {
       Design actual_design = new Design(grid: Grid.square, helices: helices);
-      actual_design = actual_design.strand(0, 20).to(10).cross(1).to(20).commit();
-      actual_design = actual_design.strand(0, 0).to(10).cross(1).to(0).commit();
+      actual_design = actual_design.draw_strand(0, 20).to(10).cross(1).to(20).commit();
+      actual_design = actual_design.draw_strand(0, 0).to(10).cross(1).to(0).commit();
 
       Design expected_design = new Design(grid: Grid.square, helices: helices);
       expected_design = expected_design.rebuild((s) => s
@@ -357,7 +357,7 @@ main() {
     test('test_strand__multiple_strands_overlap_no_error', () {
       Design actual_design = new Design(grid: Grid.square, helices: helices);
       actual_design = actual_design
-          .strand(0, 0)
+          .draw_strand(0, 0)
           .to(10)
           .cross(1)
           .to(0)
@@ -372,7 +372,7 @@ main() {
                   unused_fields: BuiltMap<String, Object>()))
           .commit();
       actual_design = actual_design
-          .strand(0, 10)
+          .draw_strand(0, 10)
           .to(0)
           .cross(1)
           .to(10)
@@ -416,7 +416,7 @@ main() {
     });
     test('test_strand__call_to_twice_legally', () {
       Design actual_design = new Design(grid: Grid.square, helices: helices);
-      actual_design = actual_design.strand(0, 0).to(10).cross(1).to(5).to(0).commit();
+      actual_design = actual_design.draw_strand(0, 0).to(10).cross(1).to(5).to(0).commit();
 
       Design expected_design = new Design(grid: Grid.square, helices: helices);
       expected_design = expected_design.rebuild((s) => s

--- a/test/oxdna_export_test.dart
+++ b/test/oxdna_export_test.dart
@@ -54,8 +54,8 @@ main() {
       */
       var helices = [for (int i = 0; i < 2; i++) Helix(idx: i, max_offset: 7, grid: Grid.square)];
       var design = Design(helices: helices, grid: Grid.square);
-      design = design.strand(0, 0).to(7).cross(1).move(-7).commit();
-      design = design.strand(0, 7).move(-7).cross(1).move(7).commit();
+      design = design.draw_strand(0, 0).to(7).cross(1).move(-7).commit();
+      design = design.draw_strand(0, 7).move(-7).cross(1).move(7).commit();
 
       // expected values for verification
       int expected_num_nucleotides = 7 * 4;
@@ -208,8 +208,8 @@ main() {
             grid: Grid.square, position: Position3D(x: 100, y: 0, z: 0), helices_view_order: [2, 3]),
       };
       var design = Design(helices: helices, grid: Grid.square, groups: groups);
-      design = design.strand(0, 0).to(7).cross(1).move(-7).commit();
-      design = design.strand(2, 7).move(-7).cross(3).move(7).commit();
+      design = design.draw_strand(0, 0).to(7).cross(1).move(-7).commit();
+      design = design.draw_strand(2, 7).move(-7).cross(3).move(7).commit();
 
       // expected values for verification
       int expected_num_nucleotides = 7 * 4;
@@ -349,7 +349,7 @@ main() {
         HelixBuilder()..idx= 2..grid_position=GridPosition(0, 2).toBuilder()..max_offset=8,
       ];
       var design = Design(helix_builders: helix_builders, grid: Grid.honeycomb);
-      design = design.strand(0, 0).to(8).cross(1).move(-8).cross(2).to(8).commit();
+      design = design.draw_strand(0, 0).to(8).cross(1).move(-8).cross(2).to(8).commit();
 
       // expected values for verification
       int expected_num_nucleotides = 8 * 3;
@@ -454,7 +454,7 @@ main() {
       */
       var helix = [Helix(idx: 0, max_offset: 7, grid: Grid.square)];
       var design = Design(helices: helix, grid: Grid.square);
-      design = design.strand(0, 0).to(7).add_deletion(0, 4).commit();
+      design = design.draw_strand(0, 0).to(7).add_deletion(0, 4).commit();
 
       // expected values for verification
       int expected_num_nucleotides = 6;
@@ -557,7 +557,7 @@ main() {
       */
       var helix = [Helix(idx: 0, max_offset: 10, grid: Grid.square)];
       var design = Design(helices: helix, grid: Grid.square);
-      design = design.strand(0, 0).to(7).add_insertion(0, 4, 1).commit();
+      design = design.draw_strand(0, 0).to(7).add_insertion(0, 4, 1).commit();
 
       // expected values for verification
       int expected_num_nucleotides = 8;
@@ -661,8 +661,8 @@ main() {
       */
       var helix = [Helix(idx: 0, max_offset: 14, grid: Grid.square)];
       var design = Design(helices: helix, grid: Grid.square);
-      design = design.strand(0, 0).to(4).loopout(0, 4).to(7).commit();
-      design = design.strand(0, 7).to(0).commit();
+      design = design.draw_strand(0, 0).to(4).loopout(0, 4).to(7).commit();
+      design = design.draw_strand(0, 7).to(0).commit();
 
       // expected values for verification
       int expected_num_nucleotides = 7 * 2 + 4;

--- a/test/paste_test.dart
+++ b/test/paste_test.dart
@@ -45,8 +45,8 @@ main() {
     setUp(() {
       helices = [for (int helix in all_helices) Helix(idx: helix, max_offset: 40, grid: Grid.square)];
       Design design = Design(helices: helices, grid: Grid.square);
-      design = design.strand(0, 0).move(10).commit();
-      design = design.strand(0, 20).move(10).cross(1).move(-5).commit();
+      design = design.draw_strand(0, 0).move(10).commit();
+      design = design.draw_strand(0, 20).move(10).cross(1).move(-5).commit();
       orig_strand = design.strands[0];
       second_strand = design.strands[1];
       store = store_from_design(design);
@@ -468,7 +468,7 @@ main() {
         'group2': HelixGroup(grid: Grid.square, helices_view_order: [5, 4, 7, 6]),
       };
       Design design = Design(helices: helices, grid: Grid.square, groups: groups);
-      design = design.strand(0, 0).move(10).cross(1).move(-10).commit();
+      design = design.draw_strand(0, 0).move(10).cross(1).move(-10).commit();
       orig_strand = design.strands.first;
       store = store_from_design(design);
     });
@@ -613,7 +613,7 @@ main() {
     setUp(() {
       helices = [for (int helix in all_helices) Helix(idx: helix, max_offset: 40, grid: Grid.square)];
       Design design = Design(helices: helices, grid: Grid.square);
-      design = design.strand(0, 0).move(10).commit();
+      design = design.draw_strand(0, 0).move(10).commit();
       orig_strand = design.strands.first;
       store = store_from_design(design);
       state = store.state;
@@ -881,9 +881,9 @@ main() {
       */
 
       // add strands on all helices
-      Design design = state.design.strand(1, 0).to(10).commit();
-      design = design.strand(2, 0).to(10).commit();
-      design = design.strand(3, 0).to(10).commit();
+      Design design = state.design.draw_strand(1, 0).to(10).commit();
+      design = design.draw_strand(2, 0).to(10).commit();
+      design = design.draw_strand(3, 0).to(10).commit();
       store = store_from_design(design);
       state = store.state;
 

--- a/test/reducer_test.dart
+++ b/test/reducer_test.dart
@@ -7607,7 +7607,7 @@ main() {
     Helix helix0 = Helix(idx: 0, grid_position: GridPosition(0, 0), max_offset: 8);
     Helix helix1 = Helix(idx: 1, grid_position: GridPosition(0, 1), max_offset: 8);
     Design design = Design(helices: [helix0, helix1], grid: Grid.square)
-        .strand(0, 0)
+        .draw_strand(0, 0)
         .to(8)
         .cross(1)
         .to(0)
@@ -7652,7 +7652,7 @@ main() {
     Helix helix0 = Helix(idx: 0, grid_position: GridPosition(0, 0), max_offset: 16);
     Helix helix1 = Helix(idx: 1, grid_position: GridPosition(0, 1), max_offset: 16);
     Design design = Design(helices: [helix0, helix1], grid: Grid.square)
-        .strand(1, 8)
+        .draw_strand(1, 8)
         .to(0)
         .cross(0)
         .to(8)


### PR DESCRIPTION
## Description
Fixed bug with Undo after "Inline insertions/deletions".

## Related Issue
#761 

## How Has This Been Tested?
Opened the design described in the issue and ensured that expected behavior happens. I'm also going to add unit tests. (Hence this PR being a draft for now.)