### PR TITLE
793 remove loading message when program crashes

### DIFF
--- a/lib/src/view/design_main_error_boundary.dart
+++ b/lib/src/view/design_main_error_boundary.dart
@@ -120,5 +120,6 @@ class DesignMainErrorBoundaryComponent<T extends DesignMainErrorBoundaryProps,
 
 send_error(String escaped_error_message) async{
   app.dispatch(actions.ErrorMessageSet(escaped_error_message));
+  app.dispatch(actions.LoadingDialogHide());    // close loading dialog if it's currently being shown
   app.view.design_view.render(app.state);
 }


### PR DESCRIPTION
I don't know if this covers all scenarios where an error pops up. So far it works as expected when a component in `view/` throws.