### PR TITLE
Should fix 825: import cadnano -  domains that end on deletions

### DIFF
--- a/lib/src/state/design.dart
+++ b/lib/src/state/design.dart
@@ -2125,6 +2125,23 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
         else
           start = old_base;
 
+	bool running = true;
+	while(running){
+	  switch(Design._cadnano_v2_import_extract_end_deletions(vstrands[old_helix]['skip'], start,end)){
+	    case -1:{
+	      start = start + 1;
+	    }
+	    break;
+	    case 1:{
+	      end = end-1;
+	    }
+	    break;
+	    case 0:{
+	      running = false;
+	    }
+	  }
+	}
+
         domains.add(Domain(
             is_scaffold: strand_type == 'scaf',
             helix: old_helix,
@@ -2172,6 +2189,19 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
       }
     }
     return to_return;
+  }
+
+
+  /// Routines which finds cadnano skips that correspond to domain ends. Returns -1 if they appear at the start, +1 if they appear at the end, or 0 if there are no end deletions.
+  static int _cadnano_v2_import_extract_end_deletions(List<dynamic> skip_table, int start, int end){
+    if ((skip_table[start] == -1)){
+      return -1;
+    }
+    if (skip_table[end] == -1){
+      return 1;
+    } else {
+      return 0;
+    }
   }
 
   /// Routines which converts cadnano skips to scadnano insertions


### PR DESCRIPTION
Import from cadnano can now shorten domains that end on a deletion (or multiple deletions).

## Description
Modified design.dart to look at domains and recognize which ones end on deletions.
Possibly unwanted behavior: it will shorten a scaffold too, if deletions are at either of its ends. 
It might not be the best way of doing this, and it's for sure not elegant, but it might be helpful to have a first implementation.

## Related Issue
https://github.com/UC-Davis-molecular-computing/scadnano/issues/825

## Motivation and Context
Avoids warning stars when importing from cadnano, automates a tedious compatibility task.

## How Has This Been Tested?
Tried on multiple deletions located at strand ends.
Could not run extensive tests on this machine (no google chrome). 


