### PR TITLE
Add CanDo Atomic model CSV Export

### DIFF
--- a/lib/src/actions/actions.dart
+++ b/lib/src/actions/actions.dart
@@ -1924,6 +1924,27 @@ abstract class ExportDNA with BuiltJsonSerializable implements Action, Built<Exp
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Export CanDo CSV DNA
+
+abstract class ExportCanDoDNA with BuiltJsonSerializable implements Action, Built<ExportCanDoDNA, ExportCanDoDNABuilder> {
+  ExportDNAFormat get export_dna_format;
+  factory ExportCanDoDNA(
+  {
+   ExportDNAFormat export_dna_format,
+  }) {
+    return ExportCanDoDNA.from((b) => b
+    ..export_dna_format = export_dna_format);
+  }
+
+  factory ExportCanDoDNA.from([void Function(ExportCanDoDNABuilder) updates]) = _$ExportCanDoDNA;
+
+  ExportCanDoDNA._();
+
+  static Serializer<ExportCanDoDNA> get serializer => _$exportCanDoDNASerializer;
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Export SVG
 
 enum ExportSvgType { main, side, both }

--- a/lib/src/middleware/export_dna_sequences.dart
+++ b/lib/src/middleware/export_dna_sequences.dart
@@ -1,4 +1,5 @@
 import 'package:redux/redux.dart';
+import 'package:scadnano/src/state/export_dna_format_strand_order.dart';
 
 import '../app.dart';
 import '../state/strand.dart';
@@ -10,6 +11,54 @@ export_dna_sequences_middleware(Store<AppState> store, action, NextDispatcher ne
   next(action);
 
   AppState state = store.state;
+
+// Export CSV DNA for CanDo.
+if (action is actions.ExportCanDoDNA) {
+    List<Strand> strands;
+      strands = state.design.strands.toList();
+      strands.removeWhere((strand) => strand.is_scaffold);
+
+    String filename = 'cando_sequences.csv';
+    util.BlobType blob_type = util.BlobType.text;
+
+    try {
+      var result = action.export_dna_format
+        .export(strands, strand_order: StrandOrder.five_prime, column_major: true);
+      // See export comments for why we have this stupid special case
+      if (result is Future<List<int>>) {
+        result.then((response) {
+          List<int> content = response;
+          util.save_file(filename, content, blob_type: blob_type);
+        }).catchError((e, stackTrace) {
+          var cause = "";
+          if (has_cause(e)) {
+            cause = e.cause;
+          } else if (has_message(e)) {
+            cause = e.message;
+          }
+          var msg = cause + '\n\n' + stackTrace.toString();
+          store.dispatch(actions.ErrorMessageSet(msg));
+          app.view.design_view.render(store.state);
+        });
+      } else {
+        String content = result;
+        util.save_file(filename, content, blob_type: blob_type);
+      }
+      // .then((content) => util.save_file(filename, content, blob_type: blob_type))
+    } catch (e, stackTrace) {
+      var cause = "";
+      if (has_cause(e)) {
+        cause = e.cause;
+      } else if (has_message(e)) {
+        cause = e.message;
+      }
+      var msg = cause + '\n\n' + stackTrace.toString();
+      store.dispatch(actions.ErrorMessageSet(msg));
+      app.view.design_view.render(store.state);
+    }
+  }
+
+// Export DNA for other platforms.
   if (action is actions.ExportDNA) {
     List<Strand> strands;
     if (action.include_only_selected_strands) {

--- a/lib/src/state/export_dna_format.dart
+++ b/lib/src/state/export_dna_format.dart
@@ -98,6 +98,7 @@ class ExportDNAFormat extends EnumClass {
 
   static Serializer<ExportDNAFormat> get serializer => _$exportDNAFormatSerializer;
 
+  static const ExportDNAFormat cando = _$cando;
   static const ExportDNAFormat csv = _$csv;
   static const ExportDNAFormat idt_bulk = _$idt_bulk;
   static const ExportDNAFormat idt_plates96 = _$idt_plates96;
@@ -109,6 +110,8 @@ class ExportDNAFormat extends EnumClass {
 
   String extension() {
     switch (this) {
+      case cando: // This is not used.
+        return 'csv';
       case csv:
         return 'csv';
       case idt_bulk:
@@ -121,6 +124,7 @@ class ExportDNAFormat extends EnumClass {
   }
 
   static const Map<ExportDNAFormat, String> _toString_map = {
+    cando: 'CANDO', // This should not appear in the 'DNA Sequences' UI - see 1271 of lib/src/view/menu.dart
     csv: 'CSV (.csv)',
     idt_bulk: 'IDT Bulk (.txt)',
     idt_plates96: 'IDT 96-well plate(s) (.xlsx)',
@@ -142,6 +146,8 @@ class ExportDNAFormat extends EnumClass {
 
   bool text_file() {
     switch (this) {
+      case cando: // This is not used.
+        return true;
       case csv:
         return true;
       case idt_bulk:
@@ -155,6 +161,8 @@ class ExportDNAFormat extends EnumClass {
 
   util.BlobType blob_type() {
     switch (this) {
+      case cando: // This is not used.
+        return util.BlobType.text;
       case csv:
         return util.BlobType.text;
       case idt_bulk:
@@ -182,6 +190,8 @@ class ExportDNAFormat extends EnumClass {
 
     try {
       switch (this) {
+        case cando:
+          return cando_compatible_csv_export(strands_sorted);
         case csv:
           return csv_export(strands_sorted);
         case idt_bulk:
@@ -208,6 +218,31 @@ class ExportDNAException implements Exception {
   String cause;
 
   ExportDNAException(this.cause);
+}
+
+String cando_compatible_csv_export(Iterable<Strand> strands) {
+  StringBuffer buf = StringBuffer();
+  // Write the CSV header
+  buf.writeln('Start,End,Sequence,Length,Color');
+  for (var strand in strands) {
+    // If the export name contains 'SCAF', then it's a scaffold strand, so we do not export it for cando.
+    if (strand.idt_export_name().contains('SCAF')) {
+      continue;
+    }
+    // Remove the characters 'ST' from the start of the export name as cando doesn't understand them.
+    var cando_strand = strand.idt_export_name().replaceAll(RegExp(r'^ST'), '');
+    // Split the export name into the start and end positions.
+    RegExp cando_split_regex = RegExp(r'\d+\[\d+\]');
+    List<String> cando_split_name = cando_split_regex.allMatches(cando_strand).map((match) => match.group(0)).toList();
+    if (cando_split_name.length != 2) {
+      throw ExportDNAException('Invalid strand name: ${strand.idt_export_name()}');
+    }
+    var cando_strand_end = cando_split_name[1];
+    var cando_strand_start = cando_split_name[0];
+    // Write the strand to the CSV file.
+    buf.writeln('${cando_strand_start},${cando_strand_end},${idt_sequence_null_aware(strand)},${idt_sequence_null_aware(strand).length},${strand.color.toHexColor().toCssString().toUpperCase()}');
+  }
+  return buf.toString();
 }
 
 String csv_export(Iterable<Strand> strands) {

--- a/lib/src/view/menu.dart
+++ b/lib/src/view/menu.dart
@@ -1040,6 +1040,10 @@ debugging, but be warned that it will be very slow to render a large number of D
         ..on_click = ((_) => app.disable_keyboard_shortcuts_while(export_dna))
         ..tooltip = "Export DNA sequences of strands to a file."
         ..display = 'DNA sequences')(),
+      (MenuDropdownItem()
+        ..on_click = ((_) => props.dispatch(actions.ExportCanDoDNA(export_dna_format: ExportDNAFormat.cando)))
+        ..tooltip = "Export DNA sequences of strands as a CSV for use with CanDo's Atomic Model processing."
+        ..display = 'CanDo DNA Sequences')(),
       DropdownDivider({'key': 'divider-not-full-design'}),
       (MenuDropdownItem()
         ..on_click = ((_) => props.dispatch(actions.ExportCadnanoFile(whitespace: true)))
@@ -1261,6 +1265,13 @@ However, it may be less stable than the main site.'''
   Future<void> export_dna() async {
     List<String> export_options = ExportDNAFormat.values.map((v) => v.toString()).toList();
     List<String> sort_options = StrandOrder.values.map((v) => v.toString()).toList();
+
+    // This is needed to hide the cando export option from the menu, as it has a separate button due to how specific CanDo is with CSV format.
+    for (var option in export_options) {
+      if (option == "CANDO") {
+        export_options.remove(option);
+      }
+    }
 
     int idx_include_scaffold = 0;
     int idx_include_only_selected_strands = 1;


### PR DESCRIPTION
This pull request changes a few files. It is half of PR #850, is based on the dev branch and conversation about CanDo Export should be continued here.

It changes the Export drop-down to add a new feature - 'CanDo DNA Sequences'. This exports the file in the cadnano2 format, accepted by CanDo's Atomic Model generator.

## Description
I have added a `ExportCanDoDNA` class, alongside the `ExportDNA` class. This is used separate from the [Export > DNA sequences] dialogue as certain settings need to be set in order for CanDo to accept the CSV. ( Include Scaffold: false, Include only selected strands: false, Sort stands: true, Column Major order: true, Strand part to sort by: 5' ), so this would not work with the existing dialogue. I have added a case for `ExportCanDoDNA` in `middleware/export_dna_sequences.dart` that uses these settings, along with the main `cando_compatible_csv_export` function itself. This function is called by the `cando` ExportDNAFormat, which is hidden from the [Export > DNA sequences] dialogue.

## Related Issue
This pull request fixes issue #570, requesting an export for CanDo feature since Feb 7, 2021.

## Motivation and Context
I wanted to add this feature as manually writing the CSV file and copying color values etc. is a lot of manual work when it could be done by scadnano easily.

## How Has This Been Tested?
I tested this by comparing it to manually edited `.csv` files that I confirmed worked with CanDo, and it created the exact same result. Unit tests may need to be written for this in the future.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/26520767/229758213-2cf9eb83-9688-4451-a426-0ceef2f9dd8f.png)
![image](https://user-images.githubusercontent.com/26520767/229758328-46422494-2afe-435f-9e08-42b62c0c8061.png)

Thanks for checking out my code! Sorry if I made any breaking changes or have not followed the design organisation of the project, but I have made my best effort to keep it simple.