### PR TITLE
469 add ability to edit domainstrandloopout labels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -387,9 +387,9 @@ straightforward to make, adding React components and Redux middleware
 unit tests is an [ongoing issue](https://github.com/UC-Davis-molecular-computing/scadnano/issues/32).
 
 ### Formatting Dart code
-This step is done so that Pull Requests will only show "substantial semantic" changes and not minor whitespace changes. It will also be useful in helping to review code changes more quickly by focusing only on changes that actually affect the code logic.
+This step is done so that Pull Requests will only show "substantial semantic" changes and not minor whitespace changes. It is useful in helping to review code changes more quickly by focusing only on changes that actually affect the code logic.
 
-Before making a Pull Request, all the dart code must be formatted using one of the below given options. If this step is not done, the formatting check for the Pull Request will fail.
+Before making a Pull Request, all the Dart code must be formatted using one of the below given options. If this step is not done, the formatting check for the Pull Request will fail.
 
 - **VS Code:**
 1. Download and install VS Code from [here](https://code.visualstudio.com/download) if not already installed.
@@ -412,7 +412,7 @@ At this point, your VS Code editor should have been set up to automatically form
 - **IntelliJ IDEA (a.k.a. WebStorm):**
 1. Download and install IntelliJ IDEA from [here](https://www.jetbrains.com/idea/download/) if not already installed.
 2. Open the scadnano project on the editor.
-3. Shortcut for Preferences: (Windows) Ctrl + Alt + , or  (MacOS) Cmd + ,
+3. Shortcut for Preferences: (Windows) Ctrl + Alt + S or  (MacOS) Cmd + ,
 4. Navigate to Preferences -> Plugins. Search and install the Dart Plugin. (You might have to point the plugin to the already installed Dart SDK v2.13)
 5. Navigate to Preferences -> Editor -> Code Style -> Dart and change the line length to 110.
 6. Navigate to Preferences -> Tools -> Actions on Save and check the Reformat code option.

--- a/lib/src/actions/actions.dart
+++ b/lib/src/actions/actions.dart
@@ -371,7 +371,7 @@ abstract class SelectModesSet
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Strand/domain/loopout names
+// Strand/domain/loopout names/labels
 
 // used to set or remove (set name=null to remove)
 abstract class StrandNameSet
@@ -397,7 +397,30 @@ abstract class StrandNameSet
 }
 
 // used to set or remove (set name=null to remove)
-// used for both Domains and Loopouts
+abstract class StrandLabelSet
+    with BuiltJsonSerializable, UndoableAction
+    implements SingleStrandAction, Built<StrandLabelSet, StrandLabelSetBuilder> {
+  @nullable
+  Object get label;
+
+  Strand get strand;
+
+  /************************ begin BuiltValue boilerplate ************************/
+  factory StrandLabelSet({Object label, Strand strand}) = _$StrandLabelSet._;
+
+  StrandLabelSet._();
+
+  static Serializer<StrandLabelSet> get serializer => _$strandLabelSetSerializer;
+
+  @memoized
+  int get hashCode;
+
+  @override
+  String short_description() => "set strand label";
+}
+
+// used to set or remove (set name=null to remove)
+// used for Domains, Loopouts, and Extensions
 abstract class SubstrandNameSet
     with BuiltJsonSerializable, UndoableAction
     implements StrandPartAction, Built<SubstrandNameSet, SubstrandNameSetBuilder> {
@@ -420,6 +443,32 @@ abstract class SubstrandNameSet
 
   @override
   String short_description() => "set ${substrand.type_description()} name";
+}
+
+// used to set or remove (set name=null to remove)
+// used for Domains, Loopouts, and Extensions
+abstract class SubstrandLabelSet
+    with BuiltJsonSerializable, UndoableAction
+    implements StrandPartAction, Built<SubstrandLabelSet, SubstrandLabelSetBuilder> {
+  @nullable
+  Object get label;
+
+  Substrand get substrand;
+
+  StrandPart get strand_part => substrand;
+
+  /************************ begin BuiltValue boilerplate ************************/
+  factory SubstrandLabelSet({Object label, Substrand substrand}) = _$SubstrandLabelSet._;
+
+  SubstrandLabelSet._();
+
+  static Serializer<SubstrandLabelSet> get serializer => _$substrandLabelSetSerializer;
+
+  @memoized
+  int get hashCode;
+
+  @override
+  String short_description() => "set ${substrand.type_description()} label";
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/lib/src/reducers/strands_reducer.dart
+++ b/lib/src/reducers/strands_reducer.dart
@@ -115,6 +115,7 @@ Reducer<Strand> strand_part_reducer = combineReducers([
   TypedReducer<Strand, actions.ExtensionDisplayLengthAngleSet>(extension_display_length_angle_change_reducer),
   TypedReducer<Strand, actions.InsertionOrDeletionAction>(insertion_deletion_reducer),
   TypedReducer<Strand, actions.SubstrandNameSet>(substrand_name_set_reducer),
+  TypedReducer<Strand, actions.SubstrandLabelSet>(substrand_label_set_reducer),
 ]);
 
 Strand substrand_name_set_reducer(Strand strand, actions.SubstrandNameSet action) {
@@ -128,6 +129,27 @@ Strand substrand_name_set_reducer(Strand strand, actions.SubstrandNameSet action
     substrand = (substrand as Loopout).rebuild((b) => b..name = action.name);
   } else if (substrand is Extension) {
     substrand = (substrand as Extension).rebuild((b) => b..name = action.name);
+  } else {
+    throw AssertionError('substrand must be Domain, Loopout, or Extension');
+  }
+
+  var substrands = strand.substrands.toList();
+  substrands[substrand_idx] = substrand;
+  strand = strand.rebuild((s) => s..substrands.replace(substrands));
+  return strand;
+}
+
+Strand substrand_label_set_reducer(Strand strand, actions.SubstrandLabelSet action) {
+  int substrand_idx = strand.substrands.indexOf(action.substrand);
+
+  // we do the same thing no matter if its Domain, Loopout, or Extension, but need to cast to call rebuild
+  Substrand substrand = action.substrand;
+  if (substrand is Domain) {
+    substrand = (substrand as Domain).rebuild((b) => b..label = action.label);
+  } else if (substrand is Loopout) {
+    substrand = (substrand as Loopout).rebuild((b) => b..label = action.label);
+  } else if (substrand is Extension) {
+    substrand = (substrand as Extension).rebuild((b) => b..label = action.label);
   } else {
     throw AssertionError('substrand must be Domain, Loopout, or Extension');
   }
@@ -554,6 +576,7 @@ Reducer<Strand> single_strand_reducer = combineReducers([
   TypedReducer<Strand, actions.ModificationRemove>(modification_remove_reducer),
   TypedReducer<Strand, actions.ModificationEdit>(modification_edit_reducer),
   TypedReducer<Strand, actions.StrandNameSet>(strand_name_set_reducer),
+  TypedReducer<Strand, actions.StrandLabelSet>(strand_label_set_reducer),
   TypedReducer<Strand, actions.ScalePurificationIDTFieldsAssign>(
       scale_purification_idt_fields_assign_reducer),
   TypedReducer<Strand, actions.PlateWellIDTFieldsAssign>(plate_well_idt_fields_assign_reducer),
@@ -593,6 +616,9 @@ Strand scale_purification_idt_fields_assign_reducer(
 
 Strand strand_name_set_reducer(Strand strand, actions.StrandNameSet action) =>
     strand.rebuild((b) => b..name = action.name);
+
+Strand strand_label_set_reducer(Strand strand, actions.StrandLabelSet action) =>
+    strand.rebuild((b) => b..label = action.label);
 
 Strand extension_add_reducer(Strand strand, actions.ExtensionAdd action) {
   var substrands = strand.substrands.toList();

--- a/lib/src/serializers.dart
+++ b/lib/src/serializers.dart
@@ -75,6 +75,8 @@ part 'serializers.g.dart';
   ScalePurificationIDTFieldsAssign,
   StrandNameSet,
   SubstrandNameSet,
+  StrandLabelSet,
+  SubstrandLabelSet,
   DomainNameMismatch,
   ShowBasePairLinesSet,
   ShowBasePairLinesWithMismatchesSet,

--- a/lib/src/state/dialog.dart
+++ b/lib/src/state/dialog.dart
@@ -29,7 +29,9 @@ class DialogType extends EnumClass {
   static const DialogType assign_plate_well = _$assign_plate_well;
   static const DialogType add_modification = _$add_modification;
   static const DialogType set_strand_name = _$set_strand_name;
+  static const DialogType set_strand_label = _$set_strand_label;
   static const DialogType set_domain_name = _$set_domain_name;
+  static const DialogType set_substrand_label = _$set_substrand_label;
   static const DialogType assign_dna_sequence = _$assign_dna_sequence;
   static const DialogType remove_dna_sequence = _$remove_dna_sequence;
   static const DialogType edit_modification = _$edit_modification;

--- a/lib/src/state/selectable.dart
+++ b/lib/src/state/selectable.dart
@@ -19,6 +19,7 @@ import 'strand.dart';
 import '../app.dart';
 import '../constants.dart' as constants;
 import '../util.dart' as util;
+import 'substrand.dart';
 
 part 'selectable.g.dart';
 
@@ -35,6 +36,10 @@ abstract class SelectablesStore
 
   @memoized
   BuiltSet<Strand> get selected_strands => BuiltSet<Strand>.from(selected_items.where((s) => s is Strand));
+
+  @memoized
+  BuiltSet<Strand> get selected_substrands =>
+      BuiltSet<Strand>.from(selected_items.where((s) => s is Substrand));
 
   @memoized
   BuiltSet<Crossover> get selected_crossovers =>

--- a/lib/src/view/design_footer.dart
+++ b/lib/src/view/design_footer.dart
@@ -48,11 +48,16 @@ class DesignFooterComponent extends UiComponent2<DesignFooterProps> {
       if (mouseover_data.domain != null) {
         int domain_length = mouseover_data.domain.dna_length();
         var strand = props.strand_first_mouseover_data;
+        var domain = mouseover_data.domain;
         text += (', ' +
             'strand DNA index: ${mouseover_data.strand_idx}, ' +
             'domain length: ${domain_length}, ' +
             'strand length: ${strand.dna_length}, ' +
-            (strand.name != null ? 'strand name: ${strand.name} ' : ''));
+            (domain?.name != null ? 'domain name: ${domain.name}, ' : '') +
+            (domain?.label != null ? 'domain label: ${domain.label}, ' : '') +
+            (strand.name != null ? 'strand name: ${strand.name}, ' : '') +
+            (strand.label != null ? 'strand label: ${strand.label} ' : '')
+        );
         ;
       }
     } else {

--- a/lib/src/view/design_footer.dart
+++ b/lib/src/view/design_footer.dart
@@ -56,8 +56,7 @@ class DesignFooterComponent extends UiComponent2<DesignFooterProps> {
             (domain?.name != null ? 'domain name: ${domain.name}, ' : '') +
             (domain?.label != null ? 'domain label: ${domain.label}, ' : '') +
             (strand.name != null ? 'strand name: ${strand.name}, ' : '') +
-            (strand.label != null ? 'strand label: ${strand.label} ' : '')
-        );
+            (strand.label != null ? 'strand label: ${strand.label} ' : ''));
         ;
       }
     } else {

--- a/lib/src/view/design_main_strand_extension.dart
+++ b/lib/src/view/design_main_strand_extension.dart
@@ -23,6 +23,7 @@ import '../state/extension.dart';
 import '../util.dart' as util;
 import '../state/selectable.dart';
 import 'design_main_strand_dna_end.dart';
+import 'design_main_strand.dart' as design_main_strand;
 import 'pure_component.dart';
 import '../state/context_menu.dart';
 import '../actions/actions.dart' as actions;
@@ -174,13 +175,21 @@ class DesignMainExtensionComponent extends UiComponent2<DesignMainExtensionProps
               title: 'remove extension name',
               on_click: () => app.dispatch(actions.SubstrandNameSet(name: null, substrand: props.ext))),
         ContextMenuItem(
+          title: 'set extension label',
+          on_click: set_extension_label,
+        ),
+        if (props.ext.label != null)
+          ContextMenuItem(
+              title: 'remove extension label',
+              on_click: () => app.dispatch(actions.SubstrandLabelSet(label: null, substrand: props.ext))),
+        ContextMenuItem(
           title: 'set extension color',
           on_click: () => app
               .dispatch(actions.StrandOrSubstrandColorPickerShow(strand: props.strand, substrand: props.ext)),
         ),
         if (props.ext.color != null)
           ContextMenuItem(
-              title: 'remove loopout color',
+              title: 'remove extension color',
               on_click: () => app.dispatch(actions.StrandOrSubstrandColorSet(
                   strand: props.strand, substrand: props.ext, color: null))),
       ];
@@ -204,6 +213,12 @@ class DesignMainExtensionComponent extends UiComponent2<DesignMainExtensionProps
   }
 
   set_extension_name() => app.disable_keyboard_shortcuts_while(ask_for_extension_name);
+
+  set_extension_label() => app.disable_keyboard_shortcuts_while(() => design_main_strand.ask_for_label(
+        props.strand,
+        props.ext,
+        app.state.ui_state.selectables_store.selected_substrands,
+      ));
 
   Future<void> ask_for_extension_name() async {
     int name_idx = 0;

--- a/lib/src/view/design_main_strand_loopout.dart
+++ b/lib/src/view/design_main_strand_loopout.dart
@@ -19,6 +19,7 @@ import '../state/strand.dart';
 import '../state/domain.dart';
 import '../state/loopout.dart';
 import '../app.dart';
+import 'design_main_strand.dart' as design_main_strand;
 import '../util.dart' as util;
 import '../constants.dart' as constants;
 import 'pure_component.dart';
@@ -167,6 +168,14 @@ class DesignMainLoopoutComponent extends UiStatefulComponent2<DesignMainLoopoutP
               title: 'remove loopout name',
               on_click: () => app.dispatch(actions.SubstrandNameSet(name: null, substrand: props.loopout))),
         ContextMenuItem(
+          title: 'set loopout label',
+          on_click: set_loopout_label,
+        ),
+        if (props.loopout.label != null)
+          ContextMenuItem(
+              title: 'remove loopout label',
+              on_click: () => app.dispatch(actions.SubstrandLabelSet(substrand: props.loopout, label: null))),
+        ContextMenuItem(
           title: 'set loopout color',
           on_click: () => app.dispatch(
               actions.StrandOrSubstrandColorPickerShow(strand: props.strand, substrand: props.loopout)),
@@ -211,6 +220,12 @@ class DesignMainLoopoutComponent extends UiStatefulComponent2<DesignMainLoopoutP
   }
 
   set_loopout_name() => app.disable_keyboard_shortcuts_while(ask_for_loopout_name);
+
+  set_loopout_label() => app.disable_keyboard_shortcuts_while(() => design_main_strand.ask_for_label(
+        props.strand,
+        props.loopout,
+        app.state.ui_state.selectables_store.selected_substrands,
+      ));
 
   Future<void> ask_for_loopout_name() async {
     int name_idx = 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added right-click menu items for editing labels.

## Related Issue
#469

## Motivation and Context
Previously users could only edit labels in the Python package or by manually editing the `.sc` file.

## How Has This Been Tested?
I tried out the new menu items and verified that edits properly update the design.

