### PR TITLE
884 disallow assigning dna complements when there are unpaired deletionsinsertions

### DIFF
--- a/lib/src/middleware/assign_dna.dart
+++ b/lib/src/middleware/assign_dna.dart
@@ -11,9 +11,10 @@ assign_dna_middleware(Store<AppState> store, action, NextDispatcher next) {
       action.assign_complements &&
       action.disable_change_sequence_bound_strand) {
     // This pops up the error to the user if they try to change the DNA sequence of a bound strand
-    // through assigning DNA to a strand it is bound to.
+    // through assigning DNA to a strand it is bound to,
+    // or other errors such as unpaired deletions/insertions.
     try {
-      assign_dna_reducer(store.state.design.strands, action);
+      assign_dna_reducer(store.state.design.strands, store.state, action);
     } on ArgumentError catch (e) {
       window.alert(e.message);
       return;

--- a/lib/src/reducers/assign_or_remove_dna_reducer.dart
+++ b/lib/src/reducers/assign_or_remove_dna_reducer.dart
@@ -155,8 +155,9 @@ String compute_dna_complement_from(
       if (unpaired_addresses.isNotEmpty) {
         var first_unpaired_address = unpaired_addresses.first;
         var err_msg = "I cannot assign DNA complements when there is an unpaired deletion or insertion, "
-            "but I found one at this address: helix idx=${first_unpaired_address.helix_idx}, "
-            "offset=${first_unpaired_address.offset}";
+            "but I found one at this address:\n"
+            "helix idx=${first_unpaired_address.helix_idx}, offset=${first_unpaired_address.offset}\n"
+            "To view all of them in the design, go to View-->Show unpaired deletions/insertions.";
         throw ArgumentError(err_msg);
       }
 

--- a/lib/src/reducers/strands_reducer.dart
+++ b/lib/src/reducers/strands_reducer.dart
@@ -34,13 +34,13 @@ import 'util_reducer.dart';
 import '../util.dart' as util;
 
 Reducer<BuiltList<Strand>> strands_local_reducer = combineReducers([
-  TypedReducer<BuiltList<Strand>, actions.AssignDNA>(assign_dna_reducer),
   TypedReducer<BuiltList<Strand>, actions.RemoveDNA>(remove_dna_reducer),
   TypedReducer<BuiltList<Strand>, actions.ReplaceStrands>(replace_strands_reducer),
   TypedReducer<BuiltList<Strand>, actions.SingleStrandAction>(strands_single_strand_reducer),
 ]);
 
 GlobalReducer<BuiltList<Strand>, AppState> strands_global_reducer = combineGlobalReducers([
+  TypedGlobalReducer<BuiltList<Strand>, AppState, actions.AssignDNA>(assign_dna_reducer),
   TypedGlobalReducer<BuiltList<Strand>, AppState, actions.AssignDomainNameComplementFromBoundStrands>(//
       assign_domain_name_complement_from_bound_strands_reducer),
   TypedGlobalReducer<BuiltList<Strand>, AppState, actions.AssignDomainNameComplementFromBoundDomains>(//


### PR DESCRIPTION
## Description
Prevents assigning DNA complements when there is an unpaired insertion or deletion.

## Related Issue
#884 

## Motivation and Context
The error given before this fix was confusing. This more directly indicates the problem.

