### PR TITLE
fixes #902: make menu dropdown wider for Edit-->Copy/Paste/Select

### DIFF
--- a/lib/src/view/menu_dropdown_item.dart
+++ b/lib/src/view/menu_dropdown_item.dart
@@ -30,10 +30,8 @@ class MenuDropdownItemComponent extends UiComponent2<MenuDropdownItemProps> {
         'disabled': props.disabled,
         'onClick': props.on_click,
       },
-      props.display,
-      props.keyboard_shortcut != null
-          ? (Dom.span()..className = 'dropdown-item-keyboard-shortcut-span')(props.keyboard_shortcut)
-          : null,
+      Dom.span()(props.display),
+      props.keyboard_shortcut,
     );
 
     if (props.tooltip == null) {

--- a/web/scadnano-styles.css
+++ b/web/scadnano-styles.css
@@ -923,9 +923,13 @@ https://stackoverflow.com/questions/15138801/rotate-rectangle-around-its-own-cen
     line-height: 0.8rem;
 }
 
-/* Thicken the dropdown vertical spacing */
+/* Thicken the dropdown vertical spacing and use flexbox */
 .dropdown-item {
     padding: .5rem 1.5rem;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    column-gap: 1rem;
 }
 
 /* Since the dropdowns are links, need to overwrite default colors */
@@ -1039,12 +1043,6 @@ https://stackoverflow.com/questions/15138801/rotate-rectangle-around-its-own-cen
 /* Hides the data-browse psuedo-element. */
 .form-file-dropdown .custom-file-input + .custom-file-label::after {
     content: none;
-}
-
-.dropdown-item-keyboard-shortcut-span {
-    float: right;
-    width: 33%;
-    position: relative;
 }
 
 /************************************************


### PR DESCRIPTION
The issue was that the `float: right` CSS property on the keyboard shortcut element was causing the element's width to not be considered when computing the entire menu's width. This PR changes dropdown items to use flexbox with `justify-content: space-between` to align the keyboard shortcut to the right.