### PR TITLE
fixed example, but problem with #921 still remains

### DIFF
--- a/web/examples/output_designs/2_staple_2_helix_origami_deletions_insertions_mods.sc
+++ b/web/examples/output_designs/2_staple_2_helix_origami_deletions_insertions_mods.sc
@@ -6,9 +6,9 @@
     {"max_offset": 48, "grid_position": [0, 1]}
   ],
   "modifications_in_design": {
-    "/5Biosg/": {
+    "5'-/5Biosg/": {
       "display_text": "B",
-      "idt_text": "/5Biosg/",
+      "idt_text": "5'-/5Biosg/",
       "display_connector": false,
       "location": "5'"
     }
@@ -40,7 +40,7 @@
         {"helix": 0, "forward": false, "start": 24, "end": 40, "insertions": [[26, 2]]},
         {"helix": 1, "forward": true, "start": 24, "end": 40}
       ],
-      "5prime_modification": "/5Biosg/"
+      "5prime_modification": "5'-/5Biosg/"
     }
   ]
 }


### PR DESCRIPTION
## Description
Partially addresses #921. This fixes the example design "2_staple_2_helix_origami_deletions_insertions_mods" to use the key `"5'-/5Biosg/"` instead of `"/5Biosg/"`, to match what future biotins added with the IDT text `"/5Biosg/"` would have as a key (with the `"5'-"` prepended). However, there's still some inconsistency with mixing mods added via the web interface (where `"5'-"` and `"3'-"` would be prepended to the key) versus created via the Python package (where the key could be something else).

## Related Issue
#921
