### PR TITLE
moved "Show helix coordinates in side view" to View-->Helices submenu and made helix dialogs for setting grid position and position not use saved responses

### DIFF
--- a/lib/src/middleware/helix_hide_all.dart
+++ b/lib/src/middleware/helix_hide_all.dart
@@ -26,7 +26,7 @@ helix_hide_all_middleware(Store<AppState> store, dynamic action, NextDispatcher 
       var msg = 'The option "Display only selected helices" is enabled. '
           'Since no helices are selected, none will be displayed in the main view.\n\n'
           'To display the helices, either select some helices in the side view, or disable the option '
-          '"Display only selected helices" under the "View" menu.';
+          '"View-->Helices-->Display only selected helices".';
       util.async_alert(msg);
     }
   }

--- a/lib/src/view/helix_context_menu.dart
+++ b/lib/src/view/helix_context_menu.dart
@@ -111,7 +111,8 @@ List<ContextMenuItem> context_menu_helix(Helix helix, bool helix_change_apply_to
   }
 
   Future<void> dialog_helix_set_idx() async {
-    var dialog = Dialog(title: 'set helix index', type: DialogType.set_helix_index, items: [
+    var dialog =
+        Dialog(title: 'set helix index', use_saved_response: false, type: DialogType.set_helix_index, items: [
       DialogInteger(label: 'new index', value: helix.idx),
     ]);
     List<DialogItem> results = await util.dialog(dialog);
@@ -324,10 +325,14 @@ minimum offset ${helix.min_offset} of helix ${helix.min_offset}.''');
   Future<void> dialog_helix_set_grid_position() async {
     var grid_position = helix.grid_position ?? GridPosition(0, 0);
 
-    var dialog = Dialog(title: 'set helix grid position', type: DialogType.set_helix_grid_position, items: [
-      DialogInteger(label: 'h', value: grid_position.h),
-      DialogInteger(label: 'v', value: grid_position.v),
-    ]);
+    var dialog = Dialog(
+        title: 'set helix grid position',
+        use_saved_response: false,
+        type: DialogType.set_helix_grid_position,
+        items: [
+          DialogInteger(label: 'h', value: grid_position.h),
+          DialogInteger(label: 'v', value: grid_position.v),
+        ]);
 
     List<DialogItem> results = await util.dialog(dialog);
     if (results == null) return;
@@ -341,11 +346,15 @@ minimum offset ${helix.min_offset} of helix ${helix.min_offset}.''');
   Future<void> dialog_helix_set_position() async {
     var position = helix.position ?? Position3D();
 
-    var dialog = Dialog(title: 'set helix position', type: DialogType.set_helix_position, items: [
-      DialogFloat(label: 'x', value: position.x),
-      DialogFloat(label: 'y', value: position.y),
-      DialogFloat(label: 'z', value: position.z),
-    ]);
+    var dialog = Dialog(
+        title: 'set helix position',
+        use_saved_response: false,
+        type: DialogType.set_helix_position,
+        items: [
+          DialogFloat(label: 'x', value: position.x),
+          DialogFloat(label: 'y', value: position.y),
+          DialogFloat(label: 'z', value: position.z),
+        ]);
 
     List<DialogItem> results = await util.dialog(dialog);
     if (results == null) return;

--- a/lib/src/view/menu.dart
+++ b/lib/src/view/menu.dart
@@ -923,6 +923,16 @@ toggle "Show main view helices".'''
         ..onChange = ((_) => props.dispatch(actions.ShowHelixCirclesMainViewSet(
             show_helix_circles_main_view: !props.show_helix_circles_main_view)))
         ..key = 'show-helix-circles-main-view')(),
+      (MenuBoolean()
+        ..value = props.show_grid_coordinates_side_view
+        ..display = 'Show helix coordinates in side view'
+        ..tooltip = '''\
+Displays coordinates of each helix in the side view (either grid coordinates 
+or real coordinates in nanometers, depending on whether a grid is selected).'''
+        ..name = 'show-grid-coordinates-side-view'
+        ..onChange = ((_) => props.dispatch(actions.ShowGridCoordinatesSideViewSet(
+            show_grid_coordinates_side_view: !props.show_grid_coordinates_side_view)))
+        ..key = 'show-grid-coordinates-side-view')(),
     ]);
   }
 
@@ -1066,15 +1076,6 @@ To inspect how all axes change, check View --> Show axis arrows.'''
         ..name = 'invert-y-axis'
         ..onChange = ((_) => props.dispatch(actions.InvertYSet(invert_y: !props.invert_y)))
         ..key = 'invert-y-axis')(),
-      (MenuBoolean()
-        ..value = props.show_grid_coordinates_side_view
-        ..display = 'Show grid coordinates in side view'
-        ..tooltip = '''\
-Shows grid coordinates in the side view under the helix index.'''
-        ..name = 'show-grid-coordinates-side-view'
-        ..onChange = ((_) => props.dispatch(actions.ShowGridCoordinatesSideViewSet(
-            show_grid_coordinates_side_view: !props.show_grid_coordinates_side_view)))
-        ..key = 'show-grid-coordinates-side-view')(),
       (MenuBoolean()
         ..value = props.show_helices_axis_arrows
         ..display = 'Axis arrows'


### PR DESCRIPTION
## Description
moved "Show helix coordinates in side view" to View-->Helices submenu and made helix dialogs for setting grid position and position not use saved responses

## Related Issue
#937