### PR TITLE
953 remove strand in batch

### DIFF
--- a/lib/src/view/design_main_strand.dart
+++ b/lib/src/view/design_main_strand.dart
@@ -481,7 +481,7 @@ assigned, assign the complementary DNA sequence to this strand.
                       (strand) => actions.StrandNameSet(name: null, strand: strand),
                       props.strand,
                       app.state.ui_state.selectables_store.selected_strands,
-                      'remove strand label'))),
+                      'remove strand name'))),
             ContextMenuItem(
               title: 'set domain name',
               on_click: () => set_domain_names(get_selected_domains()),

--- a/lib/src/view/design_main_strand.dart
+++ b/lib/src/view/design_main_strand.dart
@@ -928,7 +928,7 @@ PAGEHPLC : Dual PAGE & HPLC
 
     String name = (results[name_idx] as DialogText).value;
     actions.UndoableAction action = batch_if_multiple_selected(
-        name_set_strand_action_creator(name), strand, selected_strands, "set strand name");
+        name_set_strand_action_creator(name), strand, selected_strands, "set strand names");
     app.dispatch(action);
   }
 
@@ -953,7 +953,6 @@ PAGEHPLC : Dual PAGE & HPLC
 
 Future<void> ask_for_label<T extends SelectableMixin>(
     Strand strand, Substrand substrand, BuiltSet<T> selected_strands) async {
-  // T is expected to be Strand or Domain
   String part_name = 'strand';
   if (substrand != null) {
     part_name = substrand.type_description();
@@ -994,7 +993,7 @@ Future<void> ask_for_label<T extends SelectableMixin>(
   } else {
     action = actions.BatchAction(
         selected_strands.map((s) => actions.SubstrandLabelSet(label: label, substrand: (s as Substrand))),
-        "set domain labels");
+        "set substrand labels");
   }
 
   app.dispatch(action);

--- a/lib/src/view/design_main_strand_extension.dart
+++ b/lib/src/view/design_main_strand_extension.dart
@@ -173,7 +173,10 @@ class DesignMainExtensionComponent extends UiComponent2<DesignMainExtensionProps
         if (props.ext.name != null)
           ContextMenuItem(
               title: 'remove extension name',
-              on_click: () => app.dispatch(actions.SubstrandNameSet(name: null, substrand: props.ext))),
+              on_click: () => app.dispatch(actions.BatchAction(
+                  app.state.ui_state.selectables_store.selected_extensions
+                      .map((e) => actions.SubstrandNameSet(name: null, substrand: e)),
+                  "remove extension names"))),
         ContextMenuItem(
           title: 'set extension label',
           on_click: set_extension_label,
@@ -181,7 +184,10 @@ class DesignMainExtensionComponent extends UiComponent2<DesignMainExtensionProps
         if (props.ext.label != null)
           ContextMenuItem(
               title: 'remove extension label',
-              on_click: () => app.dispatch(actions.SubstrandLabelSet(label: null, substrand: props.ext))),
+              on_click: () => app.dispatch(actions.BatchAction(
+                  app.state.ui_state.selectables_store.selected_extensions
+                      .map((e) => actions.SubstrandLabelSet(label: null, substrand: e)),
+                  "remove extension labels"))),
         ContextMenuItem(
           title: 'set extension color',
           on_click: () => app
@@ -217,7 +223,7 @@ class DesignMainExtensionComponent extends UiComponent2<DesignMainExtensionProps
   set_extension_label() => app.disable_keyboard_shortcuts_while(() => design_main_strand.ask_for_label(
         props.strand,
         props.ext,
-        app.state.ui_state.selectables_store.selected_substrands,
+        app.state.ui_state.selectables_store.selected_extensions,
       ));
 
   Future<void> ask_for_extension_name() async {
@@ -230,8 +236,10 @@ class DesignMainExtensionComponent extends UiComponent2<DesignMainExtensionProps
     if (results == null) return;
 
     String name = (results[name_idx] as DialogText).value;
-    actions.UndoableAction action = actions.SubstrandNameSet(name: name, substrand: props.ext);
-    app.dispatch(action);
+    app.dispatch(actions.BatchAction(
+        app.state.ui_state.selectables_store.selected_extensions
+            .map((e) => actions.SubstrandNameSet(name: name, substrand: e)),
+        "set extension names"));
   }
 
   extension_display_length_and_angle_change() =>

--- a/lib/src/view/design_main_strand_loopout.dart
+++ b/lib/src/view/design_main_strand_loopout.dart
@@ -166,7 +166,10 @@ class DesignMainLoopoutComponent extends UiStatefulComponent2<DesignMainLoopoutP
         if (props.loopout.name != null)
           ContextMenuItem(
               title: 'remove loopout name',
-              on_click: () => app.dispatch(actions.SubstrandNameSet(name: null, substrand: props.loopout))),
+              on_click: () => app.dispatch(actions.BatchAction(
+                  app.state.ui_state.selectables_store.selected_loopouts
+                      .map((l) => actions.SubstrandNameSet(name: null, substrand: l)),
+                  "remove loopout names"))),
         ContextMenuItem(
           title: 'set loopout label',
           on_click: set_loopout_label,
@@ -174,7 +177,10 @@ class DesignMainLoopoutComponent extends UiStatefulComponent2<DesignMainLoopoutP
         if (props.loopout.label != null)
           ContextMenuItem(
               title: 'remove loopout label',
-              on_click: () => app.dispatch(actions.SubstrandLabelSet(substrand: props.loopout, label: null))),
+              on_click: () => app.dispatch(actions.BatchAction(
+                  app.state.ui_state.selectables_store.selected_loopouts
+                      .map((l) => actions.SubstrandLabelSet(label: null, substrand: l)),
+                  "remove loopout names"))),
         ContextMenuItem(
           title: 'set loopout color',
           on_click: () => app.dispatch(
@@ -224,7 +230,7 @@ class DesignMainLoopoutComponent extends UiStatefulComponent2<DesignMainLoopoutP
   set_loopout_label() => app.disable_keyboard_shortcuts_while(() => design_main_strand.ask_for_label(
         props.strand,
         props.loopout,
-        app.state.ui_state.selectables_store.selected_substrands,
+        app.state.ui_state.selectables_store.selected_loopouts,
       ));
 
   Future<void> ask_for_loopout_name() async {
@@ -237,8 +243,10 @@ class DesignMainLoopoutComponent extends UiStatefulComponent2<DesignMainLoopoutP
     if (results == null) return;
 
     String name = (results[name_idx] as DialogText).value;
-    actions.UndoableAction action = actions.SubstrandNameSet(name: name, substrand: props.loopout);
-    app.dispatch(action);
+    app.dispatch(actions.BatchAction(
+        app.state.ui_state.selectables_store.selected_loopouts
+            .map((l) => actions.SubstrandNameSet(name: name, substrand: l)),
+        "set loopout names"));
   }
 
   String loopout_path_description_between_groups() {


### PR DESCRIPTION
Fixes batch delete/set labels and names for domains and strands.

## Description
- Used ``BatchAction`` to group together set labels/name.
- Created ``get_selected_domains`` function that returns a ``BuiltSet<Domain>`` set, so setting domain names still work if 
   user selects with domain tool
- Renamed some functions like ``set_substrand_names `` to ``set_domain_names``.