### PR TITLE
 closes #870: Feature request: selection preserves color

### DIFF
--- a/lib/src/actions/actions.dart
+++ b/lib/src/actions/actions.dart
@@ -4357,7 +4357,7 @@ abstract class RetainStrandColorOnSelectionSet
   factory RetainStrandColorOnSelectionSet(bool retain_strand_color_on_selection) =>
       RetainStrandColorOnSelectionSet.from(
           (b) => b..retain_strand_color_on_selection = retain_strand_color_on_selection);
-  
+
   factory RetainStrandColorOnSelectionSet.from(
       [void Function(RetainStrandColorOnSelectionSetBuilder) updates]) = _$RetainStrandColorOnSelectionSet;
 

--- a/lib/src/actions/actions.dart
+++ b/lib/src/actions/actions.dart
@@ -4348,6 +4348,25 @@ abstract class DisablePngCachingDnaSequencesSet
       _$disablePngCachingDnaSequencesSetSerializer;
 }
 
+abstract class RetainStrandColorOnSelectionSet
+    with BuiltJsonSerializable
+    implements Action, Built<RetainStrandColorOnSelectionSet, RetainStrandColorOnSelectionSetBuilder> {
+  bool get retain_strand_color_on_selection;
+
+  /************************ begin BuiltValue boilerplate ************************/
+  factory RetainStrandColorOnSelectionSet(bool retain_strand_color_on_selection) =>
+      RetainStrandColorOnSelectionSet.from(
+          (b) => b..retain_strand_color_on_selection = retain_strand_color_on_selection);
+  
+  factory RetainStrandColorOnSelectionSet.from(
+      [void Function(RetainStrandColorOnSelectionSetBuilder) updates]) = _$RetainStrandColorOnSelectionSet;
+
+  RetainStrandColorOnSelectionSet._();
+
+  static Serializer<RetainStrandColorOnSelectionSet> get serializer =>
+      _$retainStrandColorOnSelectionSetSerializer;
+}
+
 abstract class DisplayReverseDNARightSideUpSet
     with BuiltJsonSerializable
     implements Action, Built<DisplayReverseDNARightSideUpSet, DisplayReverseDNARightSideUpSetBuilder> {

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -466,6 +466,7 @@ const css_selector_deletion = 'deletion-cross';
 const css_selector_insertion_group = 'insertion-group';
 const css_selector_deletion_group = 'deletion-group';
 const css_selector_selected = 'selected';
+const css_selector_selected_pink = 'selected-pink';
 
 const css_selector_context_menu_item_disabled = 'context_menu_item_disabled';
 

--- a/lib/src/reducers/app_ui_state_reducer.dart
+++ b/lib/src/reducers/app_ui_state_reducer.dart
@@ -213,6 +213,9 @@ int slice_bar_offset_set_reducer(int _, actions.SliceBarOffsetSet action) => act
 bool disable_png_caching_dna_sequences_reducer(bool _, actions.DisablePngCachingDnaSequencesSet action) =>
     action.disable_png_caching_dna_sequences;
 
+bool retain_strand_color_on_selection_reducer(bool _, actions.RetainStrandColorOnSelectionSet action) =>
+    action.retain_strand_color_on_selection;
+
 bool display_reverse_DNA_right_side_up_reducer(bool _, actions.DisplayReverseDNARightSideUpSet action) =>
     action.display_reverse_DNA_right_side_up;
 
@@ -434,6 +437,7 @@ AppUIStateStorables app_ui_state_storable_local_reducer(AppUIStateStorables stor
     ..show_slice_bar = TypedReducer<bool, actions.ShowSliceBarSet>(show_slice_bar_reducer)(storables.show_slice_bar, action)
     ..slice_bar_offset = TypedReducer<int, actions.SliceBarOffsetSet>(slice_bar_offset_set_reducer)(storables.slice_bar_offset, action)
     ..disable_png_caching_dna_sequences = TypedReducer<bool, actions.DisablePngCachingDnaSequencesSet>(disable_png_caching_dna_sequences_reducer)(storables.disable_png_caching_dna_sequences, action)
+    ..retain_strand_color_on_selection = TypedReducer<bool, actions.RetainStrandColorOnSelectionSet>(retain_strand_color_on_selection_reducer)(storables.retain_strand_color_on_selection, action)
     ..display_reverse_DNA_right_side_up = TypedReducer<bool, actions.DisplayReverseDNARightSideUpSet>(display_reverse_DNA_right_side_up_reducer)(storables.display_reverse_DNA_right_side_up, action)
     ..local_storage_design_choice = TypedReducer<LocalStorageDesignChoice, actions.LocalStorageDesignChoiceSet>(local_storage_design_choice_reducer)(storables.local_storage_design_choice, action).toBuilder()
     ..clear_helix_selection_when_loading_new_design = TypedReducer<bool, actions.ClearHelixSelectionWhenLoadingNewDesignSet>(clear_helix_selection_when_loading_new_design_set_reducer)(storables.clear_helix_selection_when_loading_new_design, action)

--- a/lib/src/serializers.dart
+++ b/lib/src/serializers.dart
@@ -348,6 +348,7 @@ part 'serializers.g.dart';
   SetDisplayMajorTickWidthsAllHelices,
   SliceBarOffsetSet,
   DisablePngCachingDnaSequencesSet,
+  RetainStrandColorOnSelectionSet,
   DisplayReverseDNARightSideUpSet,
   SliceBarMoveStart,
   SliceBarMoveStop,

--- a/lib/src/state/app_ui_state.dart
+++ b/lib/src/state/app_ui_state.dart
@@ -233,6 +233,8 @@ abstract class AppUIState with BuiltJsonSerializable implements Built<AppUIState
 
   bool get disable_png_caching_dna_sequences => storables.disable_png_caching_dna_sequences;
 
+  bool get retain_strand_color_on_selection => storables.retain_strand_color_on_selection;
+
   bool get display_reverse_DNA_right_side_up => storables.display_reverse_DNA_right_side_up;
 
   bool get show_mouseover_data => storables.show_mouseover_data;

--- a/lib/src/state/app_ui_state_storables.dart
+++ b/lib/src/state/app_ui_state_storables.dart
@@ -119,6 +119,8 @@ abstract class AppUIStateStorables
 
   bool get disable_png_caching_dna_sequences;
 
+  bool get retain_strand_color_on_selection;
+
   bool get display_reverse_DNA_right_side_up;
 
   bool get selection_box_intersection;
@@ -173,6 +175,7 @@ abstract class AppUIStateStorables
     b.show_slice_bar = false;
     b.slice_bar_offset = null;
     b.disable_png_caching_dna_sequences = false;
+    b.retain_strand_color_on_selection = false;
     b.display_reverse_DNA_right_side_up = false;
     b.local_storage_design_choice = LocalStorageDesignChoice().toBuilder();
     b.clear_helix_selection_when_loading_new_design = false;

--- a/lib/src/view/design_main.dart
+++ b/lib/src/view/design_main.dart
@@ -88,6 +88,7 @@ UiFactory<DesignMainProps> ConnectedDesignMain = connect<AppState, DesignMainPro
         ..invert_y = state.ui_state.invert_y
         ..selection_rope = state.ui_state.selection_rope
         ..disable_png_caching_dna_sequences = state.ui_state.disable_png_caching_dna_sequences
+        ..retain_strand_color_on_selection = state.ui_state.retain_strand_color_on_selection
         ..display_reverse_DNA_right_side_up = state.ui_state.display_reverse_DNA_right_side_up);
     }
   },
@@ -137,6 +138,7 @@ mixin DesignMainPropsMixin on UiProps {
   String displayed_group_name;
   SelectionRope selection_rope;
   bool disable_png_caching_dna_sequences;
+  bool retain_strand_color_on_selection;
   bool display_reverse_DNA_right_side_up;
   BuiltMap<int, Point<num>> helix_idx_to_svg_position_map;
   bool invert_y;
@@ -263,6 +265,7 @@ class DesignMainComponent extends UiComponent2<DesignMainProps> {
           ..only_display_selected_helices = props.only_display_selected_helices
           ..helix_idx_to_svg_position_map = props.helix_idx_to_svg_position_map
           ..disable_png_caching_dna_sequences = props.disable_png_caching_dna_sequences
+          ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
           ..display_reverse_DNA_right_side_up = props.display_reverse_DNA_right_side_up
           ..key = 'dna-sequences')(),
 

--- a/lib/src/view/design_main_dna_sequences.dart
+++ b/lib/src/view/design_main_dna_sequences.dart
@@ -33,6 +33,7 @@ mixin DesignMainDNASequencesProps on UiProps {
   bool only_display_selected_helices;
   BuiltMap<int, Point<num>> helix_idx_to_svg_position_map;
   bool disable_png_caching_dna_sequences;
+  bool retain_strand_color_on_selection;
   bool display_reverse_DNA_right_side_up;
 }
 

--- a/lib/src/view/design_main_strand.dart
+++ b/lib/src/view/design_main_strand.dart
@@ -85,6 +85,7 @@ mixin DesignMainStrandPropsMixin on UiProps {
   num modification_font_size;
   bool invert_y;
   BuiltMap<int, Point<num>> helix_idx_to_svg_position_map;
+  bool retain_strand_color_on_selection;
 }
 
 class DesignMainStrandProps = UiProps with DesignMainStrandPropsMixin, TransformByHelixGroupPropsMixin;
@@ -100,7 +101,11 @@ class DesignMainStrandComponent extends UiComponent2<DesignMainStrandProps>
 
     var classname = constants.css_selector_strand;
     if (props.selected) {
-      classname += ' ' + constants.css_selector_selected;
+      if (props.retain_strand_color_on_selection) {
+        classname += ' ' + constants.css_selector_selected;
+      } else {
+        classname += ' ' + constants.css_selector_selected_pink;
+      }
     }
     if (props.strand.is_scaffold) {
       classname += ' ' + constants.css_selector_scaffold;
@@ -149,7 +154,8 @@ class DesignMainStrandComponent extends UiComponent2<DesignMainStrandProps>
         ..moving_dna_ends = props.moving_dna_ends
         ..geometry = props.geometry
         ..helix_idx_to_svg_position_map = helix_idx_to_svg_position_y_map_on_strand
-        ..only_display_selected_helices = props.only_display_selected_helices)(),
+        ..only_display_selected_helices = props.only_display_selected_helices
+        ..retain_strand_color_on_selection = props.retain_strand_color_on_selection)(),
       _insertions(),
       _deletions(),
       if (props.show_domain_names ||
@@ -188,6 +194,7 @@ class DesignMainStrandComponent extends UiComponent2<DesignMainStrandProps>
           ..display_connector = props.modification_display_connector
           ..helix_idx_to_svg_position_y_map =
               props.helix_idx_to_svg_position_map.map((i, p) => MapEntry(i, p.y))
+          ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
           ..key = 'modifications')(),
     ]);
   }
@@ -298,6 +305,7 @@ class DesignMainStrandComponent extends UiComponent2<DesignMainStrandProps>
             ..transform = transform_of_helix(domain.helix)
             ..svg_position_y = props.helix_idx_to_svg_position_map[helix.idx].y
             ..display_reverse_DNA_right_side_up = props.display_reverse_DNA_right_side_up
+            ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
             ..key = util.id_insertion(domain, selectable_insertion.insertion.offset))());
         }
       }
@@ -332,6 +340,7 @@ class DesignMainStrandComponent extends UiComponent2<DesignMainStrandProps>
             ..selected = props.selected_deletions_in_strand.contains(selectable_deletion)
             ..transform = transform_of_helix(domain.helix)
             ..svg_position_y = props.helix_idx_to_svg_position_map[domain.helix].y
+            ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
             ..key = id)());
         }
       }

--- a/lib/src/view/design_main_strand_crossover.dart
+++ b/lib/src/view/design_main_strand_crossover.dart
@@ -38,6 +38,7 @@ mixin DesignMainStrandCrossoverPropsMixin on UiProps {
   Geometry geometry;
   num prev_domain_helix_svg_position_y;
   num next_domain_helix_svg_position_y;
+  bool retain_strand_color_on_selection;
 }
 
 class DesignMainStrandCrossoverProps = UiProps
@@ -63,7 +64,11 @@ class DesignMainStrandCrossoverComponent
 
     var classname = constants.css_selector_crossover;
     if (props.selected) {
-      classname += ' ' + constants.css_selector_selected;
+      if (props.retain_strand_color_on_selection) {
+        classname += ' ' + constants.css_selector_selected;
+      } else {
+        classname += ' ' + constants.css_selector_selected_pink;
+      }
     }
     if (props.strand.is_scaffold) {
       classname += ' ' + constants.css_selector_scaffold;

--- a/lib/src/view/design_main_strand_deletion.dart
+++ b/lib/src/view/design_main_strand_deletion.dart
@@ -26,6 +26,7 @@ mixin DesignMainStrandDeletionPropsMixin on UiProps {
   Domain get domain => selectable_deletion.domain;
   int get deletion => selectable_deletion.offset;
   num svg_position_y;
+  bool retain_strand_color_on_selection;
 }
 
 class DesignMainStrandDeletionProps = UiProps with DesignMainStrandDeletionPropsMixin;
@@ -55,7 +56,11 @@ class DesignMainStrandDeletionComponent extends UiComponent2<DesignMainStrandDel
 
     var classname = constants.css_selector_deletion_group;
     if (props.selected) {
-      classname += ' ' + constants.css_selector_selected;
+      if (props.retain_strand_color_on_selection) {
+        classname += ' ' + constants.css_selector_selected;
+      } else {
+        classname += ' ' + constants.css_selector_selected_pink;
+      }
     }
     if (props.selectable_deletion.is_scaffold) {
       classname += ' ' + constants.css_selector_scaffold;

--- a/lib/src/view/design_main_strand_dna_end.dart
+++ b/lib/src/view/design_main_strand_dna_end.dart
@@ -62,6 +62,7 @@ mixin DesignMainDNAEndPropsMixin on UiProps {
   bool drawing_potential_crossover;
   bool moving_this_dna_end;
   Point<num> helix_svg_position;
+  bool retain_strand_color_on_selection;
 }
 
 class DesignMainDNAEndProps = UiProps with DesignMainDNAEndPropsMixin;
@@ -94,7 +95,11 @@ class DesignMainDNAEndComponent extends UiComponent2<DesignMainDNAEndProps> with
     }
 
     if (props.selected) {
-      classname += ' ' + constants.css_selector_selected;
+      if (props.retain_strand_color_on_selection) {
+        classname += ' ' + constants.css_selector_selected;
+      } else {
+        classname += ' ' + constants.css_selector_selected_pink;
+      }
     }
     if (props.is_scaffold) {
       classname += ' ' + constants.css_selector_scaffold;

--- a/lib/src/view/design_main_strand_domain.dart
+++ b/lib/src/view/design_main_strand_domain.dart
@@ -51,6 +51,7 @@ mixin DesignMainDomainPropsMixin on UiProps {
   BuiltMap<int, Helix> helices;
   BuiltMap<String, HelixGroup> groups;
   Geometry geometry;
+  bool retain_strand_color_on_selection;
 }
 
 class DesignMainDomainProps = UiProps with DesignMainDomainPropsMixin, TransformByHelixGroupPropsMixin;
@@ -70,7 +71,11 @@ class DesignMainDomainComponent extends UiComponent2<DesignMainDomainProps>
 
     var classname = constants.css_selector_domain;
     if (props.selected) {
-      classname += ' ' + constants.css_selector_selected;
+      if (props.retain_strand_color_on_selection) {
+        classname += ' ' + constants.css_selector_selected;
+      } else {
+        classname += ' ' + constants.css_selector_selected_pink;
+      }
     }
     if (props.strand.is_scaffold) {
       classname += ' ' + constants.css_selector_scaffold;

--- a/lib/src/view/design_main_strand_extension.dart
+++ b/lib/src/view/design_main_strand_extension.dart
@@ -53,6 +53,7 @@ mixin DesignMainExtensionPropsMixin on UiProps {
   BuiltMap<int, Helix> helices;
   BuiltMap<String, HelixGroup> groups;
   Geometry geometry;
+  bool retain_strand_color_on_selection;
 }
 
 class DesignMainExtensionProps = UiProps with DesignMainExtensionPropsMixin, TransformByHelixGroupPropsMixin;
@@ -76,7 +77,11 @@ class DesignMainExtensionComponent extends UiComponent2<DesignMainExtensionProps
 
     var classname = constants.css_selector_extension;
     if (props.selected) {
-      classname += ' ' + constants.css_selector_selected;
+      if (props.retain_strand_color_on_selection) {
+        classname += ' ' + constants.css_selector_selected;
+      } else {
+        classname += ' ' + constants.css_selector_selected_pink;
+      }
     }
     if (props.strand.is_scaffold) {
       classname += ' ' + constants.css_selector_scaffold;

--- a/lib/src/view/design_main_strand_insertion.dart
+++ b/lib/src/view/design_main_strand_insertion.dart
@@ -39,6 +39,8 @@ mixin DesignMainStrandInsertionPropsMixin on UiProps {
   Insertion get insertion => selectable_insertion.insertion;
 
   Domain get domain => selectable_insertion.domain;
+
+  bool retain_strand_color_on_selection;
 }
 
 class DesignMainStrandInsertionProps = UiProps with DesignMainStrandInsertionPropsMixin;
@@ -50,7 +52,11 @@ class DesignMainStrandInsertionComponent extends UiComponent2<DesignMainStrandIn
   render() {
     var classname = constants.css_selector_insertion_group;
     if (props.selected) {
-      classname += ' ' + constants.css_selector_selected;
+      if (props.retain_strand_color_on_selection) {
+        classname += ' ' + constants.css_selector_selected;
+      } else {
+        classname += ' ' + constants.css_selector_selected_pink;
+      }
     }
     if (props.selectable_insertion.is_scaffold) {
       classname += ' ' + constants.css_selector_scaffold;

--- a/lib/src/view/design_main_strand_loopout.dart
+++ b/lib/src/view/design_main_strand_loopout.dart
@@ -49,6 +49,7 @@ mixin DesignMainLoopoutPropsMixin on UiProps {
   Geometry geometry;
   num prev_helix_svg_position_y;
   num next_helix_svg_position_y;
+  bool retain_strand_color_on_selection;
 }
 
 class DesignMainLoopoutProps = UiProps with DesignMainLoopoutPropsMixin, TransformByHelixGroupPropsMixin;
@@ -69,7 +70,11 @@ class DesignMainLoopoutComponent extends UiStatefulComponent2<DesignMainLoopoutP
   render() {
     var classname = constants.css_selector_loopout;
     if (props.selected) {
-      classname += ' ' + constants.css_selector_selected;
+      if (props.retain_strand_color_on_selection) {
+        classname += ' ' + constants.css_selector_selected;
+      } else {
+        classname += ' ' + constants.css_selector_selected_pink;
+      }
     }
     if (props.strand.is_scaffold) {
       classname += ' ' + constants.css_selector_scaffold;

--- a/lib/src/view/design_main_strand_modification.dart
+++ b/lib/src/view/design_main_strand_modification.dart
@@ -49,6 +49,8 @@ mixin DesignMainStrandModificationProps on UiProps {
   num helix_svg_position_y;
 
   Extension ext; // optional; used if mod is on extension
+
+  bool retain_strand_color_on_selection;
 }
 
 class DesignMainStrandModificationComponent extends UiComponent2<DesignMainStrandModificationProps> {
@@ -87,7 +89,11 @@ class DesignMainStrandModificationComponent extends UiComponent2<DesignMainStran
     }
 
     if (props.selected) {
-      classname += ' ' + constants.css_selector_selected;
+      if (props.retain_strand_color_on_selection) {
+        classname += ' ' + constants.css_selector_selected;
+      } else {
+        classname += ' ' + constants.css_selector_selected_pink;
+      }
     }
     if (props.strand.is_scaffold) {
       classname += ' ' + constants.css_selector_scaffold;

--- a/lib/src/view/design_main_strand_modifications.dart
+++ b/lib/src/view/design_main_strand_modifications.dart
@@ -34,6 +34,8 @@ mixin DesignMainStrandModificationsPropsMixin on UiProps {
 
   BuiltSet<SelectableModification> selected_modifications_in_strand;
   BuiltMap<int, num> helix_idx_to_svg_position_y_map;
+
+  bool retain_strand_color_on_selection;
 }
 
 class DesignMainStrandModificationsProps = UiProps
@@ -65,6 +67,7 @@ class DesignMainStrandModificationsComponent extends UiComponent2<DesignMainStra
           ..helix_svg_position_y = props.helix_idx_to_svg_position_y_map[helix_5p.idx]
           ..ext = ext
           ..geometry = props.geometry
+          ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
           ..key = "5'")());
       }
     }
@@ -88,6 +91,7 @@ class DesignMainStrandModificationsComponent extends UiComponent2<DesignMainStra
           ..helix_svg_position_y = props.helix_idx_to_svg_position_y_map[helix_3p.idx]
           ..ext = ext
           ..geometry = props.geometry
+          ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
           ..key = "3'")());
       }
     }
@@ -125,6 +129,7 @@ class DesignMainStrandModificationsComponent extends UiComponent2<DesignMainStra
             ..dna_idx_mod = dna_idx_mod
             ..helix_svg_position_y = props.helix_idx_to_svg_position_y_map[helix.idx]
             ..geometry = props.geometry
+            ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
             ..key = "internal-${dna_idx_mod}")());
         }
       } else if (ss_with_mod is Loopout) {

--- a/lib/src/view/design_main_strand_paths.dart
+++ b/lib/src/view/design_main_strand_paths.dart
@@ -55,6 +55,7 @@ mixin DesignMainStrandPathsPropsMixin on UiProps {
   List<ContextMenuItem> Function(Strand strand, {Substrand substrand, Address address, ModificationType type})
       context_menu_strand;
   BuiltMap<int, Point<num>> helix_idx_to_svg_position_map;
+  bool retain_strand_color_on_selection;
 }
 
 class DesignMainStrandPathsProps = UiProps
@@ -115,6 +116,7 @@ class DesignMainStrandPathsComponent extends UiComponent2<DesignMainStrandPathsP
             ..geometry = props.geometry
             ..strand_tooltip = props.strand_tooltip
             ..helix_svg_position = props.helix_idx_to_svg_position_map[helix.idx]
+            ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
             ..key = "domain-$i")());
 
           // don't draw 5' or 3' end of a circular strand
@@ -141,6 +143,7 @@ class DesignMainStrandPathsComponent extends UiComponent2<DesignMainStrandPathsP
                 ..moving_this_dna_end = props.moving_dna_ends && end_selected
                 ..drawing_potential_crossover = props.drawing_potential_crossover
                 ..helix_svg_position = props.helix_idx_to_svg_position_map[helix.idx]
+                ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
                 ..key = key)());
               is_5p = false;
             }
@@ -170,6 +173,7 @@ class DesignMainStrandPathsComponent extends UiComponent2<DesignMainStrandPathsP
             ..next_helix = next_helix
             ..prev_helix_svg_position_y = props.helix_idx_to_svg_position_map[prev_helix.idx].y
             ..next_helix_svg_position_y = props.helix_idx_to_svg_position_map[next_helix.idx].y
+            ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
             ..key = "loopout-$i")());
         }
       } else if (substrand is Extension) {
@@ -216,6 +220,7 @@ class DesignMainStrandPathsComponent extends UiComponent2<DesignMainStrandPathsP
             ..moving_this_dna_end = props.moving_dna_ends && end_selected
             ..drawing_potential_crossover = props.drawing_potential_crossover
             ..helix_svg_position = props.helix_idx_to_svg_position_map[adj_helix.idx]
+            ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
             ..key = key)());
         }
       }
@@ -243,6 +248,7 @@ class DesignMainStrandPathsComponent extends UiComponent2<DesignMainStrandPathsP
           ..geometry = props.geometry
           ..prev_domain_helix_svg_position_y = props.helix_idx_to_svg_position_map[prev_ss.helix].y
           ..next_domain_helix_svg_position_y = props.helix_idx_to_svg_position_map[next_ss.helix].y
+          ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
           ..key = 'crossover-paths-${idx_crossover - 1}')());
       }
     }

--- a/lib/src/view/design_main_strands.dart
+++ b/lib/src/view/design_main_strands.dart
@@ -43,7 +43,8 @@ UiFactory<DesignMainStrandsProps> ConnectedDesignMainStrands =
     ..domain_label_font_size = state.ui_state.domain_label_font_size
     ..helix_idx_to_svg_position_map = state.helix_idx_to_svg_position_map
     ..display_reverse_DNA_right_side_up = state.ui_state.display_reverse_DNA_right_side_up
-    ..geometry = state.design.geometry;
+    ..geometry = state.design.geometry
+    ..retain_strand_color_on_selection = state.ui_state.retain_strand_color_on_selection;
 })(DesignMainStrands);
 
 UiFactory<DesignMainStrandsProps> DesignMainStrands = _$DesignMainStrands;
@@ -73,6 +74,7 @@ mixin DesignMainStrandsProps on UiProps {
   bool display_reverse_DNA_right_side_up;
   Geometry geometry;
   BuiltMap<int, Point<num>> helix_idx_to_svg_position_map;
+  bool retain_strand_color_on_selection;
 }
 
 class DesignMainStrandsComponent extends UiComponent2<DesignMainStrandsProps> with PureComponent {
@@ -131,6 +133,7 @@ class DesignMainStrandsComponent extends UiComponent2<DesignMainStrandsProps> wi
         ..geometry = props.geometry
         ..helix_idx_to_svg_position_map = props.helix_idx_to_svg_position_map
         ..display_reverse_DNA_right_side_up = props.display_reverse_DNA_right_side_up
+        ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
         ..key = strand.toString())());
     }
 

--- a/lib/src/view/menu.dart
+++ b/lib/src/view/menu.dart
@@ -89,6 +89,7 @@ UiFactory<MenuProps> ConnectedMenu = connect<AppState, MenuProps>(
       ..show_slice_bar = state.ui_state.show_slice_bar
       ..show_mouseover_data = state.ui_state.show_mouseover_data
       ..disable_png_caching_dna_sequences = state.ui_state.disable_png_caching_dna_sequences
+      ..retain_strand_color_on_selection = state.ui_state.retain_strand_color_on_selection
       ..display_reverse_DNA_right_side_up = state.ui_state.display_reverse_DNA_right_side_up
       ..local_storage_design_choice = state.ui_state.local_storage_design_choice
       ..clear_helix_selection_when_loading_new_design =
@@ -151,6 +152,7 @@ mixin MenuPropsMixin on UiProps {
   bool show_loopout_extension_length;
   bool show_mouseover_data;
   bool disable_png_caching_dna_sequences;
+  bool retain_strand_color_on_selection;
   bool display_reverse_DNA_right_side_up;
   bool default_crossover_type_scaffold_for_setting_helix_rolls;
   bool default_crossover_type_staple_for_setting_helix_rolls;
@@ -1141,6 +1143,19 @@ debugging, but be warned that it will be very slow to render a large number of D
           props.dispatch(actions.DisablePngCachingDnaSequencesSet(!props.disable_png_caching_dna_sequences));
         }
         ..key = 'disable-png-caching-dna-sequences')(),
+      (MenuBoolean()
+        ..value = props.retain_strand_color_on_selection
+        ..display = 'Retain strand color on selection'
+        ..tooltip = '''\
+Selected strands are normally highlighted in hot pink, which overrides the strand's color.
+Select this option to not override the strand's color when it is selected.
+A highlighting effect will still appear.
+        '''
+        ..name = 'retain-strand-color-on-selection'
+        ..onChange = (_) {
+          props.dispatch(actions.RetainStrandColorOnSelectionSet(!props.retain_strand_color_on_selection));
+        }
+        ..key = 'retain-strand-color-on-selection')(),
     ];
   }
 

--- a/web/scadnano-styles.css
+++ b/web/scadnano-styles.css
@@ -684,7 +684,6 @@ label + select {
     fill: lightgray;
 }
 
-
 /* https://www.w3schools.com/cssref/css_selectors.asp */
 /* These are needed to make parts pink when they are selected individually. */
 .selected.crossover-curve,
@@ -693,7 +692,31 @@ label + select {
 .selected.deletion-cross,
 .selected.modification,
 .selected.domain-line,
-.selected.extension-line {
+.selected.extension-line,
+.selected .crossover-curve,
+.selected .loopout-curve,
+.selected .insertion-curve,
+.selected .deletion-cross,
+.selected .modification,
+.selected .domain-line,
+.selected .extension-line {
+    stroke-width: 5pt;
+}
+
+.selected-pink.crossover-curve,
+.selected-pink.loopout-curve,
+.selected-pink.insertion-curve,
+.selected-pink.deletion-cross,
+.selected-pink.modification,
+.selected-pink.domain-line,
+.selected-pink.extension-line,
+.selected-pink .crossover-curve,
+.selected-pink .loopout-curve,
+.selected-pink .insertion-curve,
+.selected-pink .deletion-cross,
+.selected-pink .modification,
+.selected-pink .domain-line,
+.selected-pink .extension-line {
     stroke: hotpink;
     stroke-width: 5pt;
 }
@@ -702,35 +725,35 @@ label + select {
 .selected.three-prime-end,
 .selected.five-prime-end-first-substrand,
 .selected.three-prime-end-last-substrand {
+    visibility: visible;
+    stroke-width: 1pt;
+}
+
+.selected-pink.five-prime-end,
+.selected-pink.three-prime-end,
+.selected-pink.five-prime-end-first-substrand,
+.selected-pink.three-prime-end-last-substrand {
     stroke: red;
     fill: hotpink;
     visibility: visible;
     stroke-width: 1pt;
 }
 
-/* https://www.w3schools.com/cssref/css_selectors.asp */
-/* These are needed to make all parts pink when whole strand is selected, */
-/* i.e., a parent of these components is selected */
-.selected .crossover-curve,
-.selected .loopout-curve,
-.selected .insertion-curve,
-.selected .deletion-cross,
-.selected .modification,
-.selected .domain-line,
-.selected .extension-line {
-    stroke: hotpink;
-    stroke-width: 5pt;
-}
-
 .selected .five-prime-end,
 .selected .three-prime-end,
 .selected .five-prime-end-first-substrand,
 .selected .three-prime-end-last-substrand {
+    stroke-width: 1pt;
+}
+
+.selected-pink .five-prime-end,
+.selected-pink .three-prime-end,
+.selected-pink .five-prime-end-first-substrand,
+.selected-pink .three-prime-end-last-substrand {
     stroke: red;
     fill: hotpink;
     stroke-width: 1pt;
 }
-
 
 /* end formatting of Strand elements when selected/selectable/not selectable */
 /*****************************************************************************/


### PR DESCRIPTION
Adds menu option "Retain strand color on selection" in the View menu. When this is enabled, strands are not shown in hot pink when selected, but still have the shadow effect and a slightly larger stroke width. Works by using a different CSS class depending on the option.