### PR TITLE
fixes #959: display DNA sequence on extension in order 5' to 3'

### DIFF
--- a/lib/src/view/design_main_strand_extension.dart
+++ b/lib/src/view/design_main_strand_extension.dart
@@ -255,10 +255,16 @@ class DesignMainExtensionComponent extends UiComponent2<DesignMainExtensionProps
     if (results == null) return;
 
     String name = (results[name_idx] as DialogText).value;
-    app.dispatch(actions.BatchAction(
-        app.state.ui_state.selectables_store.selected_extensions
-            .map((e) => actions.SubstrandNameSet(name: name, substrand: e)),
-        "set extension names"));
+    var selected_exts = app.state.ui_state.selectables_store.selected_extensions;
+    var action;
+    if (selected_exts.length > 1) {
+      action = actions.BatchAction(
+          selected_exts.map((e) => actions.SubstrandNameSet(name: name, substrand: e)),
+          "set extension names");
+    } else {
+      action = actions.SubstrandNameSet(name: name, substrand: props.ext);
+    }
+    app.dispatch(action);
   }
 
   extension_display_length_and_angle_change() =>

--- a/lib/src/view/design_main_strand_extension.dart
+++ b/lib/src/view/design_main_strand_extension.dart
@@ -89,12 +89,24 @@ class DesignMainExtensionComponent extends UiComponent2<DesignMainExtensionProps
 
     // To ensure that the extension name displays right-side up, we always draw from the
     // left point to the right point, regardless of which is the free end and which is attached.
-    var left_svg = extension_free_end_svg;
-    var right_svg = extension_attached_end_svg;
-    if (left_svg.x > right_svg.x) {
-      var swap = left_svg;
-      left_svg = right_svg;
-      right_svg = swap;
+    //NOTE: this causes the DNA to appear backwards in cases when the 3' end appears to the left
+    // of the 5' end. For now we will ditch this and draw the extension path from 5' to 3'
+    // (see svg_5p and svg_3p below), and figure out later how to display the name properly.
+    // Leaving this code here to help with that later.
+    // var left_svg = extension_free_end_svg;
+    // var right_svg = extension_attached_end_svg;
+    // if (left_svg.x > right_svg.x) {
+    //   var swap = left_svg;
+    //   left_svg = right_svg;
+    //   right_svg = swap;
+    // }
+
+    var svg_5p = extension_free_end_svg;
+    var svg_3p = extension_attached_end_svg;
+    if (!ext.is_5p) {
+      var swap = svg_5p;
+      svg_5p = svg_3p;
+      svg_3p = swap;
     }
 
     var color = ext.color ?? props.strand_color;
@@ -102,8 +114,10 @@ class DesignMainExtensionComponent extends UiComponent2<DesignMainExtensionProps
     // This is just a straight line, but for some reason, for displaying the extension name,
     // it only works to attach a textPath to it if it is a path, not a line.
     // So we use Dom.path() instead of Dom.line()
-    var path_d = 'M ${left_svg.x} ${left_svg.y} '
-        'L ${right_svg.x} ${right_svg.y}';
+    // var path_d = 'M ${left_svg.x} ${left_svg.y} '
+    //     'L ${right_svg.x} ${right_svg.y}';
+    var path_d = 'M ${svg_5p.x} ${svg_5p.y} '
+        'L ${svg_3p.x} ${svg_3p.y}';
     return (Dom.path()
       ..className = classname
       ..onPointerDown = handle_click_down

--- a/lib/src/view/design_main_strand_paths.dart
+++ b/lib/src/view/design_main_strand_paths.dart
@@ -114,6 +114,7 @@ class DesignMainStrandPathsComponent extends UiComponent2<DesignMainStrandPathsP
             ..helices = {helix.idx: helix}.build()
             ..groups = {helix.group: props.groups[helix.group]}.build()
             ..geometry = props.geometry
+            ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
             ..strand_tooltip = props.strand_tooltip
             ..helix_svg_position = props.helix_idx_to_svg_position_map[helix.idx]
             ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
@@ -139,6 +140,7 @@ class DesignMainStrandPathsComponent extends UiComponent2<DesignMainStrandPathsP
                 ..is_scaffold = props.strand.is_scaffold
                 ..selected = end_selected
                 ..strand = strand
+                ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
                 ..context_menu_strand = props.context_menu_strand
                 ..moving_this_dna_end = props.moving_dna_ends && end_selected
                 ..drawing_potential_crossover = props.drawing_potential_crossover
@@ -171,6 +173,7 @@ class DesignMainStrandPathsComponent extends UiComponent2<DesignMainStrandPathsP
             ..next_domain = next_dom
             ..prev_helix = prev_helix
             ..next_helix = next_helix
+            ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
             ..prev_helix_svg_position_y = props.helix_idx_to_svg_position_map[prev_helix.idx].y
             ..next_helix_svg_position_y = props.helix_idx_to_svg_position_map[next_helix.idx].y
             ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
@@ -194,6 +197,7 @@ class DesignMainStrandPathsComponent extends UiComponent2<DesignMainStrandPathsP
             ..strand_color = strand.color
             ..transform = transform_of_helix(adj_helix.idx)
             ..selected = props.selected_extensions_in_strand.contains(ext)
+            ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
             ..adjacent_domain = adj_dom
             ..adjacent_helix = adj_helix
             ..strand_tooltip = props.strand_tooltip
@@ -216,6 +220,7 @@ class DesignMainStrandPathsComponent extends UiComponent2<DesignMainStrandPathsP
             ..is_scaffold = props.strand.is_scaffold
             ..selected = end_selected
             ..strand = strand
+            ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
             ..context_menu_strand = props.context_menu_strand
             ..moving_this_dna_end = props.moving_dna_ends && end_selected
             ..drawing_potential_crossover = props.drawing_potential_crossover
@@ -246,6 +251,7 @@ class DesignMainStrandPathsComponent extends UiComponent2<DesignMainStrandPathsP
           ..prev_domain = prev_ss
           ..next_domain = next_ss
           ..geometry = props.geometry
+          ..retain_strand_color_on_selection = props.retain_strand_color_on_selection
           ..prev_domain_helix_svg_position_y = props.helix_idx_to_svg_position_map[prev_ss.helix].y
           ..next_domain_helix_svg_position_y = props.helix_idx_to_svg_position_map[next_ss.helix].y
           ..retain_strand_color_on_selection = props.retain_strand_color_on_selection


### PR DESCRIPTION
fixes #959: display DNA sequence on extension in order 5' to 3'.

This is done by always drawing the path for the extension 5' to 3'. Previously we drew it left-to-right, but in cases where the 3' end is to the left of the 5' end, this helped display the extension name/label right-side up, but caused the sequence to appear backward. Since the DNA sequence issue is more serious and could lead to mistakes in the design, for now we'll favor fixing that, and make separate issues to deal with

1. Displaying extension name/label right-side up in all cases.
2. Displaying DNA sequence right-side up. Currently, for cases where the 3' end is to the left of the 5' end, just like the default for reverse domains, the DNA sequence is displayed in the correct order but upside down. We'll need a separate issue to display it right-side-up when that option is selected in the View menu for reverse domains.