### PR TITLE
941 dna sequences justified

### DIFF
--- a/lib/src/actions/actions.dart
+++ b/lib/src/actions/actions.dart
@@ -2154,6 +2154,27 @@ abstract class ExportSvg with BuiltJsonSerializable implements Action, Built<Exp
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Export every text in a DNA sequence separately
+
+abstract class ExportSvgTextSeparatelySet
+    with BuiltJsonSerializable
+    implements Action, Built<ExportSvgTextSeparatelySet, ExportSvgTextSeparatelySetBuilder> {
+  bool get export_svg_text_separately;
+
+  /************************ begin BuiltValue boilerplate ************************/
+  factory ExportSvgTextSeparatelySet(bool export_svg_text_separately) =>
+      ExportSvgTextSeparatelySet.from((b) => b..export_svg_text_separately = export_svg_text_separately);
+
+  /************************ begin BuiltValue boilerplate ************************/
+  factory ExportSvgTextSeparatelySet.from([void Function(ExportSvgTextSeparatelySetBuilder) updates]) =
+      _$ExportSvgTextSeparatelySet;
+
+  ExportSvgTextSeparatelySet._();
+
+  static Serializer<ExportSvgTextSeparatelySet> get serializer => _$exportSvgTextSeparatelySetSerializer;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Strand part action
 
 // reducer takes a part of a strand and looks up the strand it's in by strand_id,

--- a/lib/src/middleware/export_svg.dart
+++ b/lib/src/middleware/export_svg.dart
@@ -54,7 +54,7 @@ export_svg_middleware(Store<AppState> store, dynamic action, NextDispatcher next
             }
           } else {
             if (store.state.ui_state.export_svg_text_separately) {
-              elt = make_portable(clone_and_apply_style(elt));
+              elt = get_cloned_svg_element_with_style([elt], store.state.ui_state.export_svg_text_separately);
             }
             _export_from_element(elt, 'main');
           }
@@ -245,7 +245,7 @@ SvgSvgElement get_cloned_svg_element_with_style(List<Element> selected_elts, boo
 
   // have to add some padding to viewbox, for some reason bbox doesn't always fit it by a few pixels??
   cloned_svg_element_with_style.setAttribute('viewBox',
-      '${bbox.x.floor() - 1} ${bbox.y.floor() - 1} ${bbox.width.ceil() + 3} ${bbox.height.ceil() + 3}');
+      '${bbox.x.floor() - 1} ${bbox.y.floor() - 1} ${bbox.width.ceil() + 3} ${bbox.height.ceil() + 6}');
 
   return cloned_svg_element_with_style;
 }

--- a/lib/src/reducers/app_ui_state_reducer.dart
+++ b/lib/src/reducers/app_ui_state_reducer.dart
@@ -233,6 +233,9 @@ bool show_base_pair_lines_with_mismatches_reducer(
         bool _, actions.ShowBasePairLinesWithMismatchesSet action) =>
     action.show_base_pair_lines_with_mismatches;
 
+bool export_svg_text_separately_reducer(bool _, actions.ExportSvgTextSeparatelySet action) =>
+    action.export_svg_text_separately;
+
 bool display_major_tick_widths_reducer(bool _, actions.SetDisplayMajorTickWidths action) => action.show;
 
 bool strand_paste_keep_color_reducer(bool _, actions.StrandPasteKeepColorSet action) => action.keep;
@@ -446,6 +449,7 @@ AppUIStateStorables app_ui_state_storable_local_reducer(AppUIStateStorables stor
     ..display_major_tick_widths_all_helices = TypedReducer<bool, actions.SetDisplayMajorTickWidthsAllHelices>(display_major_tick_widths_all_helices_reducer)(storables.display_major_tick_widths_all_helices, action)
     ..show_base_pair_lines = TypedReducer<bool, actions.ShowBasePairLinesSet>(show_base_pair_lines_reducer)(storables.show_base_pair_lines, action)
     ..show_base_pair_lines_with_mismatches = TypedReducer<bool, actions.ShowBasePairLinesWithMismatchesSet>(show_base_pair_lines_with_mismatches_reducer)(storables.show_base_pair_lines_with_mismatches, action)
+    ..export_svg_text_separately = TypedReducer<bool, actions.ExportSvgTextSeparatelySet>(export_svg_text_separately_reducer)(storables.export_svg_text_separately, action)
     ..only_display_selected_helices = TypedReducer<bool, actions.SetOnlyDisplaySelectedHelices>(only_display_selected_helices_reducer)(storables.only_display_selected_helices, action)
     ..default_crossover_type_scaffold_for_setting_helix_rolls = TypedReducer<bool, actions.DefaultCrossoverTypeForSettingHelixRollsSet>(default_crossover_type_scaffold_for_setting_helix_rolls_reducer)(storables.default_crossover_type_scaffold_for_setting_helix_rolls, action)
     ..default_crossover_type_staple_for_setting_helix_rolls = TypedReducer<bool, actions.DefaultCrossoverTypeForSettingHelixRollsSet>(default_crossover_type_staple_for_setting_helix_rolls_reducer)(storables.default_crossover_type_staple_for_setting_helix_rolls, action)

--- a/lib/src/serializers.dart
+++ b/lib/src/serializers.dart
@@ -123,6 +123,7 @@ part 'serializers.g.dart';
   ShowModificationsSet,
   ShowMismatchesSet,
   SetShowEditor,
+  ExportSvgTextSeparatelySet,
   SaveDNAFile,
   PrepareToLoadDNAFile,
   LoadDNAFile,

--- a/lib/src/state/app_ui_state.dart
+++ b/lib/src/state/app_ui_state.dart
@@ -214,6 +214,8 @@ abstract class AppUIState with BuiltJsonSerializable implements Built<AppUIState
 
   bool get show_loopout_extension_length => storables.show_loopout_extension_length;
 
+  bool get export_svg_text_separately => storables.export_svg_text_separately;
+
   bool get default_crossover_type_scaffold_for_setting_helix_rolls =>
       storables.default_crossover_type_scaffold_for_setting_helix_rolls;
 

--- a/lib/src/state/app_ui_state_storables.dart
+++ b/lib/src/state/app_ui_state_storables.dart
@@ -123,6 +123,8 @@ abstract class AppUIStateStorables
 
   bool get selection_box_intersection;
 
+  bool get export_svg_text_separately;
+
   static void _initializeBuilder(AppUIStateStorablesBuilder b) {
     // This ensures that even if these keys are not in localStorage (e.g., due to upgrading),
     // then they will be populated with a default value instead of raising an exception.
@@ -178,6 +180,7 @@ abstract class AppUIStateStorables
     b.clear_helix_selection_when_loading_new_design = false;
     b.show_mouseover_data = false;
     b.selection_box_intersection = false;
+    b.export_svg_text_separately = false;
   }
 
   /************************ begin BuiltValue boilerplate ************************/

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -1053,7 +1053,7 @@ num current_zoom(bool is_main) => is_main ? current_zoom_main_js() : current_zoo
 
 CssStyleSheet get_scadnano_stylesheet() {
   for (var stylesheet in document.styleSheets) {
-    if (stylesheet.href.contains(constants.scadnano_css_stylesheet_name)) {
+    if (stylesheet.href != null && stylesheet.href.contains(constants.scadnano_css_stylesheet_name)) {
       return stylesheet;
     }
   }

--- a/lib/src/view/design_main_dna_sequence.dart
+++ b/lib/src/view/design_main_dna_sequence.dart
@@ -92,6 +92,7 @@ class DesignMainDNASequenceComponent extends UiComponent2<DesignMainDNASequenceP
   }
 
   static const classname_dna_sequence = 'dna-seq';
+  static const charWidth = 6.59375;
 
   ReactElement _dna_sequence_on_domain(Domain domain) {
     var seq_to_draw = domain.dna_sequence_deletions_insertions_to_spaces(
@@ -135,7 +136,6 @@ class DesignMainDNASequenceComponent extends UiComponent2<DesignMainDNASequenceP
     }
 
     var id = 'dna-${util.id_domain(domain)}';
-    double charWidth = 6.59375;
 
     return (Dom.text()
       ..key = id

--- a/lib/src/view/design_main_dna_sequence.dart
+++ b/lib/src/view/design_main_dna_sequence.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:over_react/over_react.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:platform_detect/platform_detect.dart';
+import 'package:react/react_client/react_interop.dart';
 import 'package:scadnano/src/state/group.dart';
 import 'package:scadnano/src/view/transform_by_helix_group.dart';
 import 'package:tuple/tuple.dart';
@@ -134,6 +135,7 @@ class DesignMainDNASequenceComponent extends UiComponent2<DesignMainDNASequenceP
     }
 
     var id = 'dna-${util.id_domain(domain)}';
+    double charWidth = 6.59375;
 
     return (Dom.text()
       ..key = id
@@ -141,7 +143,8 @@ class DesignMainDNASequenceComponent extends UiComponent2<DesignMainDNASequenceP
       ..className = classname_dna_sequence
       ..x = '$x'
       ..y = '$y'
-      ..textLength = '$text_length'
+      // ..textLength = '$text_length'
+      ..letterSpacing = '${(text_length - charWidth * seq_to_draw.length) / (seq_to_draw.length - 1)}'
       ..transform = 'rotate(${rotate_degrees} ${rotate_x} ${rotate_y})'
       ..dy = '$dy')(seq_to_draw);
   }

--- a/lib/src/view/menu.dart
+++ b/lib/src/view/menu.dart
@@ -1167,6 +1167,16 @@ debugging, but be warned that it will be very slow to render a large number of D
         ..on_click = ((_) => props.dispatch(actions.ExportSvg(type: actions.ExportSvgType.selected)))
         ..tooltip = "Export SVG figure of selected strands"
         ..display = 'SVG of selected strands')(),
+      (MenuDropdownItem()
+        ..on_click = ((_) => app.disable_keyboard_shortcuts_while(export_dna_sequences.export_dna))
+        ..tooltip = "Export DNA sequences of strands to a file."
+        ..display = 'DNA sequences')(),
+      (MenuDropdownItem()
+        ..on_click = ((_) => props.dispatch(actions.ExportCanDoDNA()))
+        ..tooltip = "Export design's DNA sequences as a CSV in the same way as cadnano v2.\n"
+            "This is useful, for example, with CanDo's atomic model generator."
+        ..display = 'DNA sequences (cadnano v2 format)')(),
+      DropdownDivider({'key': 'divider-export-svg-settings'}),
       (MenuBoolean()
         ..value = props.export_svg_text_separately
         ..display = 'export svg text separately'
@@ -1178,15 +1188,6 @@ This is useful to circumvent an SVG bug found in Microsoft tools such as PowerPo
           props.dispatch(actions.ExportSvgTextSeparatelySet(!props.export_svg_text_separately));
         }
         ..key = 'export-svg-text-separately')(),
-      (MenuDropdownItem()
-        ..on_click = ((_) => app.disable_keyboard_shortcuts_while(export_dna_sequences.export_dna))
-        ..tooltip = "Export DNA sequences of strands to a file."
-        ..display = 'DNA sequences')(),
-      (MenuDropdownItem()
-        ..on_click = ((_) => props.dispatch(actions.ExportCanDoDNA()))
-        ..tooltip = "Export design's DNA sequences as a CSV in the same way as cadnano v2.\n"
-            "This is useful, for example, with CanDo's atomic model generator."
-        ..display = 'DNA sequences (cadnano v2 format)')(),
       DropdownDivider({'key': 'divider-not-full-design'}),
       (MenuDropdownItem()
         ..on_click = ((_) => props.dispatch(actions.ExportCadnanoFile(whitespace: true)))

--- a/lib/src/view/menu.dart
+++ b/lib/src/view/menu.dart
@@ -86,6 +86,7 @@ UiFactory<MenuProps> ConnectedMenu = connect<AppState, MenuProps>(
       ..show_grid_coordinates_side_view = state.ui_state.show_grid_coordinates_side_view
       ..show_helices_axis_arrows = state.ui_state.show_helices_axis_arrows
       ..show_loopout_extension_length = state.ui_state.show_loopout_extension_length
+      ..export_svg_text_separately = state.ui_state.export_svg_text_separately
       ..show_slice_bar = state.ui_state.show_slice_bar
       ..show_mouseover_data = state.ui_state.show_mouseover_data
       ..disable_png_caching_dna_sequences = state.ui_state.disable_png_caching_dna_sequences
@@ -154,6 +155,7 @@ mixin MenuPropsMixin on UiProps {
   bool display_reverse_DNA_right_side_up;
   bool default_crossover_type_scaffold_for_setting_helix_rolls;
   bool default_crossover_type_staple_for_setting_helix_rolls;
+  bool export_svg_text_separately;
   LocalStorageDesignChoice local_storage_design_choice;
   bool clear_helix_selection_when_loading_new_design;
   bool show_slice_bar;
@@ -1165,6 +1167,17 @@ debugging, but be warned that it will be very slow to render a large number of D
         ..on_click = ((_) => props.dispatch(actions.ExportSvg(type: actions.ExportSvgType.selected)))
         ..tooltip = "Export SVG figure of selected strands"
         ..display = 'SVG of selected strands')(),
+      (MenuBoolean()
+        ..value = props.export_svg_text_separately
+        ..display = 'export svg text separately'
+        ..tooltip = '''\
+When selected, every character of the text in a DNA sequence is exported separately.
+This is useful to circumvent an SVG bug found in Microsoft tools such as PowerPoint.'''
+        ..name = 'export-svg-text-separately'
+        ..onChange = (_) {
+          props.dispatch(actions.ExportSvgTextSeparatelySet(!props.export_svg_text_separately));
+        }
+        ..key = 'export-svg-text-separately')(),
       (MenuDropdownItem()
         ..on_click = ((_) => app.disable_keyboard_shortcuts_while(export_dna_sequences.export_dna))
         ..tooltip = "Export DNA sequences of strands to a file."


### PR DESCRIPTION
Fixes exported SVG text being unjustified on PowerPoint.

## Description
- Every `SVGTextContentElement` (`SVGTextElement`, `SVGTextPath`, etc.) is converted into character separated SVGTextElements
- Uses `getStartPositionOfChar` to get the position of individual characters in any `SVGTextContentElement`. However,
  `getStartPositionOfChar` does not carry over some specific attributes, such as `dominant-baseline` and `transform`
- `dominant-baseline `is calculated via `dominant_baseline_matrix` and `get_text_height`
- Due to some quirks with dart, `matrix_to_map`, `dom_matrix_to_map`, `point_to_map` is made to call some web API functions
- Fixed the `Cannot read properties of null (reading 'toString')` console error that appears immediately when website loads. (This is actually unrelated to justifying DNA sequences though.)
- Fixed export "SVG main view" viewbox bug, where on PowerPoint, for long SVGs, the SVG is cropped significantly.

## Related issues
- `text-shadow` does not work on PowerPoint. PowerPoint does support stroke and paint-order for texts but it looks significantly worse and grainy than without it. (Notice the "A" under the modification in the PowerPoint screenshot.)
- The viewbox of an exported SVG is slightly off (line 242-248 in export_svg.dart). If you export main view the effect is significant. (Notice the domain circle "2" is cut off slightly after exporting.)

## Screenshots
SVG on scadnano:
<img width="599" alt="Screenshot 2024-01-27 at 2 23 34 PM" src="https://github.com/UC-Davis-molecular-computing/scadnano/assets/46636772/60c22ef1-6b09-47c3-9c79-85a8196c326b">
Exported SVG after "export svg text separately" option:
<img width="599" alt="Screenshot 2024-01-27 at 2 23 49 PM" src="https://github.com/UC-Davis-molecular-computing/scadnano/assets/46636772/aced6957-76e5-46ce-93d7-49e3258790f4">
Exported SVG in PowerPoint:
<img width="599" alt="Screenshot 2024-01-27 at 2 24 03 PM" src="https://github.com/UC-Davis-molecular-computing/scadnano/assets/46636772/0bfdf8da-6792-4f9f-9cef-2ff6a923c226">
