### PR TITLE
Closes #974 DNA misalignment

### DIFF
--- a/lib/src/view/design_main_dna_sequence.dart
+++ b/lib/src/view/design_main_dna_sequence.dart
@@ -143,8 +143,8 @@ class DesignMainDNASequenceComponent extends UiComponent2<DesignMainDNASequenceP
       ..className = classname_dna_sequence
       ..x = '$x'
       ..y = '$y'
-      // ..textLength = '$text_length'
-      ..letterSpacing = '${(text_length - charWidth * seq_to_draw.length) / (seq_to_draw.length - 1)}'
+      ..textLength = '$text_length'
+      // ..letterSpacing = '${(text_length - charWidth * seq_to_draw.length) / (seq_to_draw.length - 1)}'
       ..transform = 'rotate(${rotate_degrees} ${rotate_x} ${rotate_y})'
       ..dy = '$dy')(seq_to_draw);
   }


### PR DESCRIPTION
Fixes letter spacing for all font types by switching back to textLength as opposed to letterSpacing.

## Description
We can see that the screenshot in #974, the user is using "Lucida Console", which explains the misalignment because the letterSpacing value is hardcoded for "Consolas" font. The fix the bug, we just switched back to using textLength.

## Screenshots:
![2_staple_2_helix_origami_deletions_insertions_mods_main (1)](https://github.com/UC-Davis-molecular-computing/scadnano/assets/46636772/812a6e65-866c-4f4b-b307-6df8bc7fae4f)
