### PR TITLE
996 display backbone angle correctly when `Geometry.base_pairs_per_turn` is not 10.5

### DIFF
--- a/lib/src/state/design.dart
+++ b/lib/src/state/design.dart
@@ -2033,6 +2033,8 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
   /// in degrees; gives rotation of backbone of strand in the forward direction, as viewed in the side view
   double helix_rotation_forward(int helix_idx, int offset, [double? roll = null]) {
     Helix helix = helices[helix_idx]!;
+    var group = this.groups[helix.group]!;
+    var geometry_of_helix = group.geometry ?? this.geometry;
     if (roll == null) {
       roll = helix.roll;
     }
@@ -2044,7 +2046,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
     } else {
       num_bases = 0;
     }
-    double rot = (roll + (360 * num_bases / 10.5)) % (360);
+    double rot = (roll + (360 * num_bases / geometry_of_helix.bases_per_turn)) % (360);
     return rot;
   }
 

--- a/lib/src/state/design_side_rotation_data.dart
+++ b/lib/src/state/design_side_rotation_data.dart
@@ -4,6 +4,7 @@ import 'package:color/color.dart';
 
 import '../serializers.dart';
 import 'design.dart';
+import 'geometry.dart';
 import 'helix.dart';
 import 'domain.dart';
 import 'strand.dart';
@@ -47,7 +48,7 @@ abstract class DesignSideRotationData
 
   double get roll_forward;
 
-  double get minor_groove_angle;
+  Geometry get geometry;
 
   @memoized
   int get hashCode;
@@ -79,23 +80,28 @@ abstract class DesignSideRotationData
       }
       var group = design.groups[helix.group]!;
       var geometry = group.geometry ?? design.geometry;
-      double minor_groove_angle = geometry.minor_groove_angle;
-      design_side_rotation_datas_builder.add(DesignSideRotationData(
-          helix, offset, color_forward, color_reverse, roll_forward, minor_groove_angle));
+      design_side_rotation_datas_builder
+          .add(DesignSideRotationData(helix, offset, color_forward, color_reverse, roll_forward, geometry));
     }
     return design_side_rotation_datas_builder;
   }
 
   /************************ begin BuiltValue boilerplate ************************/
-  factory DesignSideRotationData(Helix helix, int offset, Color color_forward, Color color_reverse,
-          double roll_forward, double minor_groove_angle) =>
+  factory DesignSideRotationData(
+    Helix helix,
+    int offset,
+    Color color_forward,
+    Color color_reverse,
+    double roll_forward,
+    Geometry geometry,
+  ) =>
       DesignSideRotationData.from((b) => b
         ..helix.replace(helix)
         ..offset = offset
         ..color_forward = color_forward
         ..color_reverse = color_reverse
         ..roll_forward = roll_forward
-        ..minor_groove_angle = minor_groove_angle);
+        ..geometry.replace(geometry));
 
   factory DesignSideRotationData.from([void Function(DesignSideRotationDataBuilder) updates]) =
       _$DesignSideRotationData;

--- a/lib/src/state/helix.dart
+++ b/lib/src/state/helix.dart
@@ -292,13 +292,13 @@ abstract class Helix with BuiltJsonSerializable, UnusedFields implements Built<H
     }
 
     if (json_map.containsKey(constants.major_ticks_key)) {
-      List<int> major_ticks_json = List<int>.from(json_map[constants.major_ticks_key]! as List);
+      List<int> major_ticks_json = List<int>.from(json_map[constants.major_ticks_key]!);
       helix_builder.major_ticks = ListBuilder<int>(List<int>.from(major_ticks_json));
     }
 
     if (json_map.containsKey(constants.major_tick_periodic_distances_key)) {
       List<int> major_tick_periodic_distances_json =
-          json_map[constants.major_tick_periodic_distances_key]! as List<int>;
+          List<int>.from(json_map[constants.major_tick_periodic_distances_key]!);
       helix_builder.major_tick_periodic_distances =
           ListBuilder<int>(List<int>.from(major_tick_periodic_distances_json));
     }

--- a/lib/src/view/design_side_rotation.dart
+++ b/lib/src/view/design_side_rotation.dart
@@ -19,7 +19,7 @@ mixin DesignSideRotationProps on UiProps {
 class DesignSideRotationComponent extends UiComponent2<DesignSideRotationProps> with PureComponent {
   @override
   render() {
-    double roll_reverse = props.data.roll_forward + props.data.minor_groove_angle;
+    double roll_reverse = props.data.roll_forward + props.data.geometry.minor_groove_angle;
     var color_forward_str = props.data.color_forward.toHexColor().toCssString();
     var color_reverse_str = props.data.color_reverse.toHexColor().toCssString();
 


### PR DESCRIPTION
Fixes #996