### PR TITLE
fix auto paste issue by fixing  undo action

### DIFF
--- a/lib/src/reducers/undo_redo_reducer.dart
+++ b/lib/src/reducers/undo_redo_reducer.dart
@@ -1,5 +1,6 @@
 import 'package:built_collection/built_collection.dart';
 import 'package:redux/redux.dart';
+import 'package:scadnano/src/state/copy_info.dart';
 
 import '../state/design.dart';
 import '../state/undo_redo.dart';
@@ -28,21 +29,33 @@ AppState undo_reducer(AppState state, actions.Undo action) {
 AppState state_result_after_applying_undo(AppState state, actions.Undo action) {
   Design new_design = state.design;
   UndoRedo undo_redo = state.undo_redo;
+  CopyInfo copy_info = state.ui_state.copy_info;
+  print('copy info' + copy_info.toString());
+  
+  Map<String, dynamic> new_design_copy_info = {
+    'design' : new_design,
+    'copy_info' : copy_info
+  };
+
   ListBuilder<UndoRedoItem> undo_stack = undo_redo.undo_stack.toBuilder();
   ListBuilder<UndoRedoItem> redo_stack = undo_redo.redo_stack.toBuilder();
   for (int i = 0; i < action.num_undos; i++) {
-    new_design = push_design_to_stack_and_pop_design_from_other_stack(new_design, redo_stack, undo_stack);
+    //new_design = push_design_to_stack_and_pop_design_from_other_stack(new_design, copy_info, redo_stack, undo_stack);
+    new_design_copy_info = push_design_copy_to_stack_and_pop_design_from_other_stack(new_design, copy_info, redo_stack, undo_stack);
   }
-  return create_new_state_with_new_design_and_undo_redo(state, new_design, undo_stack, redo_stack);
+  //return create_new_state_with_new_design_and_undo_redo(state, new_design, copy_info, undo_stack, redo_stack);
+  return create_new_state_with_new_design_and_undo_redo(state, new_design_copy_info['design'], new_design_copy_info['copy_info'], undo_stack, redo_stack);
 }
 
-AppState create_new_state_with_new_design_and_undo_redo(AppState old_state, Design new_design,
+AppState create_new_state_with_new_design_and_undo_redo(AppState old_state, Design new_design, CopyInfo copy_info,
     ListBuilder<UndoRedoItem> new_undo_stack, ListBuilder<UndoRedoItem> new_redo_stack) {
   bool changed_since_last_save = new_undo_stack.isNotEmpty;
 
   AppState new_model = old_state.rebuild((m) => m
     ..ui_state
-        .replace(old_state.ui_state.rebuild((u) => u..changed_since_last_save = changed_since_last_save))
+        .replace(old_state.ui_state.rebuild((u) => u
+          ..changed_since_last_save = changed_since_last_save
+          ..copy_info.replace(copy_info)))
     ..design.replace(new_design)
     ..undo_redo.replace(old_state.undo_redo.rebuild((u) => u
       ..undo_stack = new_undo_stack
@@ -56,18 +69,30 @@ AppState redo_reducer(AppState state, actions.Redo action) {
     return state;
   } else {
     Design new_design = state.design;
+    CopyInfo copy_info = state.ui_state.copy_info;
+
+  Map<String, dynamic> new_design_copy_info = {
+    'design' : new_design,
+    'copy_info' : copy_info
+  };
+
     ListBuilder<UndoRedoItem> undo_stack = undo_redo.undo_stack.toBuilder();
     ListBuilder<UndoRedoItem> redo_stack = undo_redo.redo_stack.toBuilder();
 
     for (int i = 0; i < action.num_redos; i++) {
-      new_design = push_design_to_stack_and_pop_design_from_other_stack(new_design, undo_stack, redo_stack);
+      //new_design = push_design_to_stack_and_pop_design_from_other_stack(new_design, copy_info, undo_stack, redo_stack);
+      new_design_copy_info = push_design_copy_to_stack_and_pop_design_from_other_stack(new_design, copy_info, redo_stack, undo_stack);
     }
 
     bool changed_since_last_save = undo_stack.isNotEmpty;
 
     AppState new_model = state.rebuild((m) => m
-      ..ui_state.replace(state.ui_state.rebuild((u) => u..changed_since_last_save = changed_since_last_save))
-      ..design.replace(new_design)
+      ..ui_state.replace(state.ui_state.rebuild((u) => u
+        ..changed_since_last_save = changed_since_last_save
+        // ..copy_info.replace(copy_info)))
+        ..copy_info.replace(new_design_copy_info['copy_info'])))
+      // ..design.replace(new_design)
+      ..design.replace(new_design_copy_info['design'])
       ..undo_redo.replace(undo_redo.rebuild((u) => u
         ..undo_stack = undo_stack
         ..redo_stack = redo_stack)));
@@ -76,12 +101,25 @@ AppState redo_reducer(AppState state, actions.Redo action) {
   }
 }
 
-Design push_design_to_stack_and_pop_design_from_other_stack(Design design_to_push,
+Design push_design_to_stack_and_pop_design_from_other_stack(Design design_to_push, CopyInfo copy_info,
     ListBuilder<UndoRedoItem> stack_to_push_to, ListBuilder<UndoRedoItem> stack_to_pop_from) {
   UndoRedoItem popped_item = stack_to_pop_from.removeLast();
   String popped_short_description = popped_item.short_description;
-  stack_to_push_to.add(new UndoRedoItem(popped_short_description, design_to_push));
+  stack_to_push_to.add(new UndoRedoItem(popped_short_description, design_to_push, copy_info));
   return popped_item.design;
+}
+
+Map push_design_copy_to_stack_and_pop_design_from_other_stack(Design design_to_push, CopyInfo copy_info,
+    ListBuilder<UndoRedoItem> stack_to_push_to, ListBuilder<UndoRedoItem> stack_to_pop_from) {
+  UndoRedoItem popped_item = stack_to_pop_from.removeLast();
+  String popped_short_description = popped_item.short_description;
+  stack_to_push_to.add(new UndoRedoItem(popped_short_description, design_to_push, copy_info));
+
+  Map<String, dynamic> design_copy_info = {
+    'design': popped_item.design,
+    'copy_info': popped_item.copy_info
+  };
+  return design_copy_info;
 }
 
 AppState undo_redo_clear_reducer(AppState state, actions.UndoRedoClear action) =>
@@ -90,5 +128,5 @@ AppState undo_redo_clear_reducer(AppState state, actions.UndoRedoClear action) =
 AppState undoable_action_typed_reducer(AppState state, actions.UndoableAction action) =>
     state.rebuild((m) => m
       ..undo_redo.replace(state.undo_redo.rebuild((u) => u
-        ..undo_stack.add(new UndoRedoItem(action.short_description(), state.design))
+        ..undo_stack.add(new UndoRedoItem(action.short_description(), state.design, state.ui_state.copy_info))
         ..redo_stack.clear())));

--- a/lib/src/state/undo_redo.dart
+++ b/lib/src/state/undo_redo.dart
@@ -1,6 +1,7 @@
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
+import 'package:scadnano/src/state/copy_info.dart';
 
 import '../serializers.dart';
 import 'design.dart';
@@ -38,11 +39,20 @@ abstract class UndoRedoItem with BuiltJsonSerializable implements Built<UndoRedo
 
   Design get design;
 
+  CopyInfo get copy_info;
+
   /************************ begin BuiltValue boilerplate ************************/
 
-  factory UndoRedoItem(String short_description, Design design) => UndoRedoItem.from((b) => b
+  factory UndoRedoItem(String short_description, Design design, CopyInfo copy_info) => UndoRedoItem.from((b) => b
     ..short_description = short_description
-    ..design.replace(design));
+    ..copy_info.update((c) {
+        print('I am replaced***');
+        if (copy_info != null) {
+          c.replace(copy_info);
+        }
+      })    
+    ..design.replace(design)
+    );
 
   factory UndoRedoItem.from([void Function(UndoRedoItemBuilder) updates]) = _$UndoRedoItem;
 


### PR DESCRIPTION
Fixing autopaste function issue after undoing and repasting

## Description
Fix the autopaste function after undoing by getting the copy_info from UI state and passing it in all undo & redo stack data.

## Related Issue
https://github.com/UC-Davis-molecular-computing/scadnano/issues/946
Autopaste should put the strand immediately to the right of the second strand, as happened the first time that we only had two strands. In other words we need Undo to undo not only the change to which strands are in the design, but also undo the change in internal Autopaste data  that happens after each time you press Ctrl+Shift+V.

## Motivation and Context
This fixes a bug where the index of the auto pasted strand is not updated after the undo action. 

## How Has This Been Tested?
Tested in the Chrome browser on my computer