### PR TITLE
(Fixes #987) Expand edges of base pair rectangles

### DIFF
--- a/lib/src/view/design_main_base_pair_rectangle.dart
+++ b/lib/src/view/design_main_base_pair_rectangle.dart
@@ -54,6 +54,10 @@ class DesignMainBasePairRectangleComponent extends UiComponent2<DesignMainBasePa
         List<ReactElement> helix_components = [];
         int last_offset = -2;
         var last_svg_forward_pos = null;
+
+        int starting_rect_offset = base_pairs[helix_idx]![1];
+        int ending_rect_offset = base_pairs[helix_idx]!.last;
+
         for (int offset in base_pairs[helix_idx]!) {
           var svg_position_y = props.helix_idx_to_svg_position_y_map[helix_idx]!;
           var base_svg_forward_pos = helix.svg_base_pos(offset, true, svg_position_y, geometry);
@@ -62,11 +66,28 @@ class DesignMainBasePairRectangleComponent extends UiComponent2<DesignMainBasePa
           var base_pair_ele = null;
 
           if (offset - last_offset == 1) {
+            double width_modifier = 1;
+            double x_offset = 0;
+
+            // need to move/expand the left-most square (turn into rectangle)
+            // this solves the left-side for GH issue #987
+            if (offset == starting_rect_offset) {
+              width_modifier = 1.25;
+              x_offset = -3;
+            }
+
+            // need to move/expand the right-most square (turn into rectangle)
+            // this solves the right-side for GH issue #987
+            if (offset == ending_rect_offset) {
+              width_modifier = 1.25;
+              x_offset = 0.5;
+            }
+
             base_pair_ele = (Dom.rect()
               ..id = 'base_pair-${helix_idx}-${offset}'
-              ..x = last_svg_forward_pos.x - 0.5
+              ..x = last_svg_forward_pos.x - 0.5 + x_offset
               ..y = base_svg_forward_pos.y
-              ..width = base_svg_reverse_pos.x - last_svg_forward_pos.x + 0.8
+              ..width = (base_svg_reverse_pos.x - last_svg_forward_pos.x + 0.8) * width_modifier
               ..height = base_svg_reverse_pos.y - base_svg_forward_pos.y
               ..className = constants.css_selector_base_pair_rect
               ..fill = 'grey'


### PR DESCRIPTION
There was an issue where the left-most and right-most base-pair rectangles would not expand all the way to the edge. This has now been fixed.

<!--- Provide a general summary of your changes in the Title above -->

## Description
The left-most and right-most squares have been shifted and expanded into rectangles. This fixes issue #987 where there would be some whitespace where the squares don't expand all the way to the edge.

## Related Issue
Fixes #987
To reproduce the issue, click on `View` -> `Base Pairs` then turn **on** `Display as Rectangles`. On the previous commits, this would end up with extra white space being shown at the beginning and end of the base pairs.

## Motivation and Context
This is a bug fix for issue #987.

## How Has This Been Tested?
This has been tested (and works) with each of the example DNA designs. (`File` -> `Load Example`).

Each test has been done on the Arc browser (Chromium based) as well as on Google Chrome.

## Screenshots (if appropriate):

### Left-Most Base Pair
![image](https://github.com/user-attachments/assets/36742d26-5c7b-4d70-9220-d1ab1fe57af3)

### Right-Most Base Pair
![image](https://github.com/user-attachments/assets/7a9c164b-7d68-4b42-be2b-131303c71f82)
