### PR TITLE
(Fixes #1001) Re-Added Grid Side Menu

### DIFF
--- a/lib/src/view/menu_side.dart
+++ b/lib/src/view/menu_side.dart
@@ -54,22 +54,16 @@ class SideMenuComponent extends UiComponent2<SideMenuProps> {
     }
 
     if (groups.length > 1 || props.displayed_group_name != constants.default_group_name) {
-      return Navbar(
-        {
-          'bg': 'light',
-          'expand': 'lg',
-        },
-        NavbarBrand({'key': 'side-menu-display-title'}, props.displayed_group_name),
-        groups_menu(groups),
-      );
+      return Navbar({
+        'bg': 'light',
+        'expand': 'lg',
+      }, NavbarBrand({'key': 'side-menu-display-title'}, props.displayed_group_name), groups_menu(groups),
+          grid_menu(groups));
     } else {
-      return Navbar(
-        {
-          'bg': 'light',
-          'expand': 'lg',
-        },
-        groups_menu(groups),
-      );
+      return Navbar({
+        'bg': 'light',
+        'expand': 'lg',
+      }, groups_menu(groups), grid_menu(groups));
     }
   }
 

--- a/lib/src/view/menu_side.dart
+++ b/lib/src/view/menu_side.dart
@@ -79,7 +79,6 @@ class SideMenuComponent extends UiComponent2<SideMenuProps> {
     }
     options.addAll([
       DropdownDivider({'key': 'divider-add-remove'}),
-      grid_menu(groups),
       (MenuDropdownItem()
         ..display = 'adjust current group'
         ..on_click = ((ev) => set_new_parameters_for_current_group(groups))


### PR DESCRIPTION
The grid side menu was previously missing from the dev branch.

## Description
The grid side menu just needed to be re-added to the code. It was previously in the main branch.

## Related Issue
Fixes #1001.

## Motivation and Context
The bug was specified in #1001.

## How Has This Been Tested?
It was tested on both the Arc browser (chromium-based) and Google Chrome. The grid side menu appears to be present on both now.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/48c89b4d-64db-4094-b36a-89d4ef59552d)
