### PR TITLE
Fixed #998 - Fixed a boolean logic error on line 646 of design.dart

### DIFF
--- a/lib/src/view/design.dart
+++ b/lib/src/view/design.dart
@@ -644,12 +644,13 @@ class DesignViewComponent {
       ev.preventDefault();
       app.disable_keyboard_shortcuts_while(ask_for_select_all_with_same_as_selected);
     } else if ((app.state.ui_state.edit_modes.contains(EditModeChoice.select) ||
-        app.state.ui_state.edit_modes.contains(EditModeChoice.rope_select) &&
-            ev.altKey &&
-            !(ev.ctrlKey || ev.metaKey))) {
+            app.state.ui_state.edit_modes.contains(EditModeChoice.rope_select)) &&
+        ev.altKey &&
+        !(ev.ctrlKey || ev.metaKey)) {
       // Alt+? for select modes
       ev.preventDefault(); // for some reason this is not stopping Alt+D,
       // so we also let the user type Alt+O since Alt+D has a special meaning in Chrome
+
       if (key == KeyCode.S) {
         app.dispatch(actions.SelectModeToggle(SelectModeChoice.strand));
       } else if (key == KeyCode.O || key == KeyCode.D) {


### PR DESCRIPTION
## Description
There was an error with the boolean logic on line 646 of `design.dart`. This was preventing the Chrome Dev Tools key shortcut from opening. Looking through the code, the dev tools opens on other browsers like Arc (F12) and Firefox (F12). I found out that the logic for detecting keyboard presses works properly in `index.html` so I dug deeper through the code. It turns out that `design.dart` was firing when it should not have been, preventing the default behaviour of `CTRL + SHIFT + I`.

## Related Issue
Fixes #998. This also fixes other issues where different hotkeys `CTRL + I` or `SHIFT + I` would also toggle insertion mode.

To reproduce the issue;
1) The Select (S) or Rope Select (R) tools must be enabled.
2) From there, press `CTRL + SHIFT + I`.
3) The insertion tool (ALT + I), will be selected.

For this fix, the above issue is prevented.

## Motivation and Context
This fixes #998. This caused a bit of a headache when needing to open dev tools; causing us to use our mouse and press multiple buttons instead of `CTRL + SHIFT + I`.

## How Has This Been Tested?
This was tested on Windows 11; on Chrome and Arc.