### PR TITLE
Fixed #999 - Right Justified Right Fields in Dialogs with Inputs

### DIFF
--- a/lib/src/view/design_dialog_form.dart
+++ b/lib/src/view/design_dialog_form.dart
@@ -283,6 +283,7 @@ class DesignDialogFormComponent extends UiStatefulComponent2<DesignDialogFormPro
           ..pattern = r'[+-]?(\d*[.])?\d+' // allow to type floating numbers
           ..value = item.value
           ..step = 'any'
+          ..className = 'dialog-form-item-input'
           ..onChange = (SyntheticFormEvent e) {
             var new_responses = current_responses.toBuilder();
             double? new_value = double.tryParse(e.target.value);

--- a/lib/src/view/design_dialog_form.dart
+++ b/lib/src/view/design_dialog_form.dart
@@ -283,7 +283,6 @@ class DesignDialogFormComponent extends UiStatefulComponent2<DesignDialogFormPro
           ..pattern = r'[+-]?(\d*[.])?\d+' // allow to type floating numbers
           ..value = item.value
           ..step = 'any'
-          ..className = 'dialog-form-item-input'
           ..onChange = (SyntheticFormEvent e) {
             var new_responses = current_responses.toBuilder();
             double? new_value = double.tryParse(e.target.value);

--- a/web/scadnano-styles.css
+++ b/web/scadnano-styles.css
@@ -213,6 +213,7 @@ label + select {
 /* Only apply this to labels that contain an input field */
 .dialog-form-item label:has(> .dialog-form-item-input) {
     display: flex;
+    gap: 10px;
     justify-content: space-between; /* Allow the label text and input to take up entire space. */
     align-items: center; /* Align items vertically */
 }

--- a/web/scadnano-styles.css
+++ b/web/scadnano-styles.css
@@ -204,9 +204,27 @@ label + select {
 
 .dialog-form-item {
     align-self: flex-start;
+    width: 100%;
+
+    /* Used to help left and right justify the text and input respectively. */
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     /*float: left;*/
     /*display: block;*/
 }
+
+.dialog-form-item label {
+    flex-grow: 1; /* Force label to take up available space. */
+    display: flex;
+    justify-content: space-between; /* Evenly distribute text and input. */
+    align-items: center;
+}
+
+.dialog-form-item-input {
+    margin-left: auto; /* Force input toward the right. */
+}
+
 
 .dialog-button {
     display: inline-block;

--- a/web/scadnano-styles.css
+++ b/web/scadnano-styles.css
@@ -204,21 +204,31 @@ label + select {
 
 .dialog-form-item {
     align-self: flex-start;
-    width: 100%;
 
     /*float: left;*/
     /*display: block;*/
 }
 
-/* Only apply this to labels that contain an input field */
-.dialog-form-item label:has(> input) {
+/* Only modify the width of the dialog form items that contain these specific classes. */
+.dialog-form-item:has(label > input[type="number"]),
+.dialog-form-item:has(label > input[type="text"]),
+.dialog-form-item:has(div > .radio-left) {
+    width: 100%;
+}
+
+/* Only apply to labels/divs that contain their specified elements. */
+.dialog-form-item label:has(> input[type="number"]),
+.dialog-form-item label:has(> input[type="text"]),
+.dialog-form-item div:has(> .radio-left) {
     display: flex;
     gap: 10px;
-    justify-content: space-between; /* Allow the label text and input to take up entire space. */
     align-items: center; /* Align items vertically */
 }
 
-.dialog-form-item input {
+/* Only affect specific inputs/classes that are part of the dialog form item. */
+.dialog-form-item input[type="number"],
+.dialog-form-item input[type="text"],
+.dialog-form-item .radio-left {
     margin-left: auto; /* Force label input toward the right. */
 }
 

--- a/web/scadnano-styles.css
+++ b/web/scadnano-styles.css
@@ -206,25 +206,20 @@ label + select {
     align-self: flex-start;
     width: 100%;
 
-    /* Used to help left and right justify the text and input respectively. */
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
     /*float: left;*/
     /*display: block;*/
 }
 
-.dialog-form-item label {
-    flex-grow: 1; /* Force label to take up available space. */
+/* Only apply this to labels that contain an input field */
+.dialog-form-item label:has(> .dialog-form-item-input) {
     display: flex;
-    justify-content: space-between; /* Evenly distribute text and input. */
-    align-items: center;
+    justify-content: space-between; /* Allow the label text and input to take up entire space. */
+    align-items: center; /* Align items vertically */
 }
 
 .dialog-form-item-input {
-    margin-left: auto; /* Force input toward the right. */
+    margin-left: auto; /* Force label input toward the right. */
 }
-
 
 .dialog-button {
     display: inline-block;

--- a/web/scadnano-styles.css
+++ b/web/scadnano-styles.css
@@ -211,14 +211,14 @@ label + select {
 }
 
 /* Only apply this to labels that contain an input field */
-.dialog-form-item label:has(> .dialog-form-item-input) {
+.dialog-form-item label:has(> input) {
     display: flex;
     gap: 10px;
     justify-content: space-between; /* Allow the label text and input to take up entire space. */
     align-items: center; /* Align items vertically */
 }
 
-.dialog-form-item-input {
+.dialog-form-item input {
     margin-left: auto; /* Force label input toward the right. */
 }
 


### PR DESCRIPTION
## Description
I added CSS to right justify the input in labels for the dialog box.

## Related Issue
Fixes #999. Input is now right-justified.

## Motivation and Context
Fixes #999.

## How Has This Been Tested?
Originally, the fix affected ALL dialogs, but I changed it to only affect dialogs and labels with inputs. This was tested on Windows 11, Chrome.

I am currently unsure of other forms of dialog boxes, but the two that I tested were;
**File -> Load Example**
**Edit -> Set Geometric Parameters**

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/7c3c956b-9394-4b32-be90-0289f383da5f)
