### PR TITLE
Fixes #990 - Upgrade to Dart 3

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Dart SDK Step 4
         run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
       - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/latest/linux_packages/dart_3.5.4-1_amd64.deb
+        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.4/linux_packages/dart_3.5.4-1_amd64.deb
       - name: Setup Dart SDK Step 6
         run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
       - uses: actions/checkout@v4

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -11,23 +11,21 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Setup Dart SDK Step 1
+      - name: Update APT Repositories
         run: sudo apt-get update
-      - name: Setup Dart SDK Step 2
+      - name: Install apt-transport-https
         run: sudo apt-get install apt-transport-https
-      - name: Setup Dart SDK Step 3
-        run: sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-      - name: Setup Dart SDK Step 4
-        run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-      - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_2.19.6-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/2.19.6/linux_packages/dart_2.19.6-1_amd64.deb
-      - name: Setup Dart SDK Step 6
-        run: sudo apt install /tmp/dart_2.19.6-1_amd64.deb
-      - uses: actions/checkout@v3
+      - name: Download and Add Google Linux GPG Public Key
+        run: wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/dart.gpg
+      - name: Add Dart Repository
+        run: echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
+      - name: Install Dart
+        run: sudo apt-get update && sudo apt-get install dart=3.5.4
+      - uses: actions/checkout@v4
       - name: Install dependencies
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub get
+        run: dart pub get
       - name: Run tests
-        run: PATH="$PATH:/usr/lib/dart/bin" dart run build_runner test
+        run: dart run build_runner test
 
   fail_if_pull_request_is_draft:
     if: github.event.pull_request.draft == true

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -11,21 +11,23 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Update APT Repositories
+      - name: Setup Dart SDK Step 1
         run: sudo apt-get update
-      - name: Install apt-transport-https
+      - name: Setup Dart SDK Step 2
         run: sudo apt-get install apt-transport-https
-      - name: Download and Add Google Linux GPG Public Key
-        run: wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/dart.gpg
-      - name: Add Dart Repository
-        run: echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
-      - name: Install Dart
-        run: sudo apt-get update && sudo apt-get install dart=3.5.4
+      - name: Setup Dart SDK Step 3
+        run: sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
+      - name: Setup Dart SDK Step 4
+        run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
+      - name: Setup Dart SDK Step 5
+        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/latest/linux_packages/dart_3.5.4-1_amd64.deb
+      - name: Setup Dart SDK Step 6
+        run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: dart pub get
+        run: PATH="$PATH:/usr/lib/dart/bin" dart pub get
       - name: Run tests
-        run: dart run build_runner test
+        run: PATH="$PATH:/usr/lib/dart/bin" dart run build_runner test
 
   fail_if_pull_request_is_draft:
     if: github.event.pull_request.draft == true

--- a/.github/workflows/dart_formatting.yml
+++ b/.github/workflows/dart_formatting.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Dart SDK Step 4
         run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
       - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/latest/linux_packages/dart_3.5.4-1_amd64.deb
+        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.4/linux_packages/dart_3.5.4-1_amd64.deb
       - name: Setup Dart SDK Step 6
         run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
       - uses: actions/checkout@v4

--- a/.github/workflows/dart_formatting.yml
+++ b/.github/workflows/dart_formatting.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Add Dart Repository
         run: echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
       - name: Install Dart
-        run: sudo apt-get update && sudo apt-get install dart=3.4.4
+        run: sudo apt-get update && sudo apt-get install dart=3.5.4
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart_formatting.yml
+++ b/.github/workflows/dart_formatting.yml
@@ -11,21 +11,23 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Update APT Repositories
+      - name: Setup Dart SDK Step 1
         run: sudo apt-get update
-      - name: Install apt-transport-https
+      - name: Setup Dart SDK Step 2
         run: sudo apt-get install apt-transport-https
-      - name: Download and Add Google Linux GPG Public Key
-        run: wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/dart.gpg
-      - name: Add Dart Repository
-        run: echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
-      - name: Install Dart
-        run: sudo apt-get update && sudo apt-get install dart=3.5.4
+      - name: Setup Dart SDK Step 3
+        run: sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
+      - name: Setup Dart SDK Step 4
+        run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
+      - name: Setup Dart SDK Step 5
+        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/latest/linux_packages/dart_3.5.4-1_amd64.deb
+      - name: Setup Dart SDK Step 6
+        run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: dart pub get
+        run: PATH="$PATH:/usr/lib/dart/bin" dart pub get
       - name: Verify formatting
-        run: dart format -l 110 --output=none --set-exit-if-changed .
+        run: PATH="$PATH:/usr/lib/dart/bin" dart format -l 110 --output=none --set-exit-if-changed .
 
   fail_if_pull_request_is_draft:
     if: github.event.pull_request.draft == true

--- a/.github/workflows/dart_formatting.yml
+++ b/.github/workflows/dart_formatting.yml
@@ -11,21 +11,19 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Setup Dart SDK Step 1
+      - name: Update APT Repositories
         run: sudo apt-get update
-      - name: Setup Dart SDK Step 2
+      - name: Install apt-transport-https
         run: sudo apt-get install apt-transport-https
-      - name: Setup Dart SDK Step 3
-        run: sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-      - name: Setup Dart SDK Step 4
-        run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-      - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_2.19.6-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/2.19.6/linux_packages/dart_2.19.6-1_amd64.deb
-      - name: Setup Dart SDK Step 6
-        run: sudo apt install /tmp/dart_2.19.6-1_amd64.deb
-      - uses: actions/checkout@v3
+      - name: Download and Add Google Linux GPG Public Key
+        run: wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/dart.gpg
+      - name: Add Dart Repository
+        run: echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
+      - name: Install Dart
+        run: sudo apt-get update && sudo apt-get install dart=3.4.4
+      - uses: actions/checkout@v4
       - name: Install dependencies
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub get
+        run: dart pub get
       - name: Verify formatting
         run: dart format -l 110 --output=none --set-exit-if-changed .
 

--- a/.github/workflows/gh-pages-dev.yml
+++ b/.github/workflows/gh-pages-dev.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Setup Dart SDK Step 4
         run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
       - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_2.19.6-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/2.19.6/linux_packages/dart_2.19.6-1_amd64.deb
+        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.4/linux_packages/dart_3.5.4-1_amd64.deb
       - name: Setup Dart SDK Step 6
-        run: sudo apt install /tmp/dart_2.19.6-1_amd64.deb
+        run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
 
       - name: Install dependencies
         run: PATH="$PATH:/usr/lib/dart/bin" dart pub get

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,14 +29,14 @@ jobs:
       - name: Setup Dart SDK Step 4
         run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
       - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_2.19.6-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/2.19.6/linux_packages/dart_2.19.6-1_amd64.deb
+        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.4/linux_packages/dart_3.5.4-1_amd64.deb
       - name: Setup Dart SDK Step 6
-        run: sudo apt install /tmp/dart_2.19.6-1_amd64.deb
+        run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
       - name: Install dependencies
-        run: PATH="$PATH:/usr/lib/dart/bin" pub get
+        run: PATH="$PATH:/usr/lib/dart/bin" dart pub get
 
       - name: Install webdev
-        run: PATH="$PATH:/usr/lib/dart/bin" pub global activate webdev
+        run: PATH="$PATH:/usr/lib/dart/bin" dart pub global activate webdev
 
 
       - name: Build into gh-pages repo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,23 +241,23 @@ git checkout dev
 
 ### Installing Dart
 
-This project requires using Dart version **2.19.6**, not the latest version, which is 3.x. Click on a dropdown below for installation instructions for your operating system.
+This project requires using Dart version **3.5.4**, not the latest version. Click on a dropdown below for installation instructions for your operating system.
 
 <!--TODO: Find a way to use code blocks with syntax highlighting inside <details>-->
 
 <details><summary><strong>Windows</strong></summary>
 First, install <a href="https://chocolatey.org/install">Chocolatey</a> if you haven't already. If <code>choco help</code> shows a help menu for using Chocolatey, then you've set it up correctly.
 
-Then, open a shell (cmd/Powershell) with Administrative privileges (go to Start type `cmd`, right-click on "Command Prompt", or type Powershell and right-click on "Powershell"; in both cases pick "Run as administrator") and install Dart 2.19.6:
+Then, open a shell (cmd/Powershell) with Administrative privileges (go to Start type `cmd`, right-click on "Command Prompt", or type Powershell and right-click on "Powershell"; in both cases pick "Run as administrator") and install Dart 3.5.4:
 
 <pre>
-choco install dart-sdk --version 2.19.6
+choco install dart-sdk --version 3.5.4
 </pre>
 
 To stop Chocolatey from automatically updating Dart to the latest version, pin it:
 
 <pre>
-choco pin --name="'dart-sdk'" --version="'2.19.6'"
+choco pin --name="'dart-sdk'" --version="'3.5.4'"
 </pre>
 
 </details>
@@ -267,16 +267,16 @@ First, install <a href="https://brew.sh/">Homebrew</a> if you haven't already. I
 
 It may help to run `brew tap dart-lang/dart` first.
 
-Then, install Dart 2.19.6:
+Then, install Dart 3.5.4:
 
 <pre>
-brew install dart@2.19.6
+brew install dart@3.5.4
 </pre>
 
 To stop Homebrew from automatically updating Dart to the latest version, pin it:
 
 <pre>
-brew pin dart@2.19.6
+brew pin dart@3.5.4
 </pre>
 
 If running `dart` in a terminal now does not work, you may need to follow <a href="https://docs.brew.sh/FAQ#my-mac-apps-dont-find-homebrew-utilities">these instructions</a>.
@@ -292,17 +292,17 @@ wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dea
 echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
 </pre>
 
-Then, install Dart 2.19.6:
+Then, install Dart 3.5.4:
 
 <pre>
 sudo apt-get update
-sudo apt-get install dart=2.19.6
+sudo apt-get install dart=3.5.4
 </pre>
 
 To stop apt from automatically updating Dart to the latest version, hold it:
 
 <pre>
-sudo apt-mark hold dart=2.19.6
+sudo apt-mark hold dart=3.5.4
 </pre>
 
 </details>
@@ -322,6 +322,8 @@ Try running the unit tests like this:
 ```
 dart run build_runner test
 ```
+
+If the above command fails, it should be run as sudo or an administrator.
 
 It should report something like this after running the tests:
 
@@ -347,7 +349,7 @@ Built test:test.
 `webdev` is used to run a local server for running scadnano in your browser for testing. Install it with:
 
 ```
-pub global activate webdev
+dart pub global activate webdev
 ```
 
 Note that often a message like this appears:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -29,8 +29,6 @@ linter:
   rules:
     - cancel_subscriptions
     - hash_and_equals
-    - iterable_contains_unrelated_type
-    - list_remove_unrelated_type
     - test_types_in_equals
     - unrelated_type_equality_checks
     - valid_regexps

--- a/lib/src/json_serializable.dart
+++ b/lib/src/json_serializable.dart
@@ -54,6 +54,35 @@ class SuppressableIndentEncoder extends JsonEncoder {
     return result;
   }
 }
+// class SuppressableIndentEncoder {
+//   final String indent;
+//   final bool suppress;
+//   final Replacer replacer;
+//   final JsonEncoder encoder_indent;
+//
+//   // Use composition: hold an instance of JsonEncoder
+//   final JsonEncoder encoder;
+//
+//   SuppressableIndentEncoder(Replacer replacer, {String this.indent = "  ", bool this.suppress = true})
+//       : this.replacer = replacer,
+//         this.encoder_indent = JsonEncoder.withIndent(indent),
+//         this.encoder = JsonEncoder.withIndent(indent);
+//
+//   String convert(Object? obj) {
+//     String result = encoder.convert(obj);
+//     for (var key in this.replacer.replacement_map.keys) {
+//       String val = this.replacer.replacement_map[key];
+//
+//       // Dart *really* minifies its JSON; let's make it a bit more readable
+//       // using a cheap hack to avoid replacing those ':' that occur within a JSON string key
+//       val = val.replaceAll('":', '": '); // hopefully that " is the end of the previous key
+//       val = val.replaceAll(',', ', ');
+//
+//       result = result.replaceFirst('"@@${key}@@"', val);
+//     }
+//     return result;
+//   }
+// }
 
 class Replacer {
   int unique_id = 0;

--- a/lib/src/json_serializable.dart
+++ b/lib/src/json_serializable.dart
@@ -27,7 +27,7 @@ String json_encode(JSONSerializable? obj, [bool suppress_indent = true]) {
   return json_str;
 }
 
-class SuppressableIndentEncoder extends JsonEncoder {
+class SuppressableIndentEncoder {
   final String indent;
   final bool suppress;
   final Replacer replacer;
@@ -36,13 +36,12 @@ class SuppressableIndentEncoder extends JsonEncoder {
 
   SuppressableIndentEncoder(Replacer replacer, {String this.indent = "  ", bool this.suppress = true})
       : this.replacer = replacer,
-        this.encoder_indent = JsonEncoder.withIndent(indent),
-        super(replacer.default_encode);
+        this.encoder_indent = JsonEncoder.withIndent(indent, replacer.default_encode);
 
   String convert(Object? obj) {
-    String result = super.convert(obj);
+    String result = this.encoder_indent.convert(obj);
     for (var key in this.replacer.replacement_map.keys) {
-      String val = this.replacer.replacement_map[key];
+      String val = this.replacer.replacement_map[key]!;
 
       // Dart *really* minifies its JSON; let's make it a bit more readable
       // using a cheap hack to avoid replacing those ':' that occur within a JSON string key
@@ -54,39 +53,10 @@ class SuppressableIndentEncoder extends JsonEncoder {
     return result;
   }
 }
-// class SuppressableIndentEncoder {
-//   final String indent;
-//   final bool suppress;
-//   final Replacer replacer;
-//   final JsonEncoder encoder_indent;
-//
-//   // Use composition: hold an instance of JsonEncoder
-//   final JsonEncoder encoder;
-//
-//   SuppressableIndentEncoder(Replacer replacer, {String this.indent = "  ", bool this.suppress = true})
-//       : this.replacer = replacer,
-//         this.encoder_indent = JsonEncoder.withIndent(indent),
-//         this.encoder = JsonEncoder.withIndent(indent);
-//
-//   String convert(Object? obj) {
-//     String result = encoder.convert(obj);
-//     for (var key in this.replacer.replacement_map.keys) {
-//       String val = this.replacer.replacement_map[key];
-//
-//       // Dart *really* minifies its JSON; let's make it a bit more readable
-//       // using a cheap hack to avoid replacing those ':' that occur within a JSON string key
-//       val = val.replaceAll('":', '": '); // hopefully that " is the end of the previous key
-//       val = val.replaceAll(',', ', ');
-//
-//       result = result.replaceFirst('"@@${key}@@"', val);
-//     }
-//     return result;
-//   }
-// }
 
 class Replacer {
   int unique_id = 0;
-  final Map replacement_map = {};
+  final Map<int, String> replacement_map = {};
   final JsonEncoder encoder_no_indent = JsonEncoder();
 
   dynamic default_encode(dynamic obj) {

--- a/lib/src/middleware/export_cadnano_file.dart
+++ b/lib/src/middleware/export_cadnano_file.dart
@@ -133,7 +133,8 @@ Map<String, dynamic> to_cadnano_v2_serializable(Design design, [String name = ""
 
       if (!cadnano_expected_direction) {
         throw new IllegalCadnanoDesignError(
-            'We can only convert designs where even helices have the scaffold going forward and odd helices have the scaffold going backward see the spec v2.txt Note 4. ${domain}');
+            'We can only convert designs where even helices have the scaffold going forward and odd helices '
+                'have the scaffold going backward see the spec v2.txt Note 4. ${domain}');
       }
     }
   }

--- a/lib/src/middleware/export_cadnano_file.dart
+++ b/lib/src/middleware/export_cadnano_file.dart
@@ -134,7 +134,7 @@ Map<String, dynamic> to_cadnano_v2_serializable(Design design, [String name = ""
       if (!cadnano_expected_direction) {
         throw new IllegalCadnanoDesignError(
             'We can only convert designs where even helices have the scaffold going forward and odd helices '
-                'have the scaffold going backward see the spec v2.txt Note 4. ${domain}');
+            'have the scaffold going backward see the spec v2.txt Note 4. ${domain}');
       }
     }
   }

--- a/lib/src/middleware/export_cadnano_file.dart
+++ b/lib/src/middleware/export_cadnano_file.dart
@@ -358,7 +358,7 @@ have different parity of row number: respectively ${helix_from_dct['row']} and $
   } else if (!forward_from && !forward_to) {
     helix_from_dct[strand_type][start_from]
         .setRange(2, helix_from_dct[strand_type][start_from].length, [helix_to, end_to - 1]);
-    helix_to_dct[strand_type][start_to].setRange(0, 2, [helix_from, end_from - 1]);
+    helix_to_dct[strand_type][end_to - 1].setRange(0, 2, [helix_from, start_from]);
     if (helix_from_dct['row'] % 2 != helix_to_dct['row'] % 2) {
       throw new IllegalCadnanoDesignError('''\
 Paranemic crossovers are only allowed between helices that have the same parity of 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -210,10 +210,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "4b03e11f6d5b8f6e5bb5e9f7889a56fe6c5cbe942da5378ea4d4d7f73ef9dfe5"
+      sha256: e3493833ea012784c740e341952298f1cc77f1f01b1bbc3eb4eecf6984fb7f43
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   crypto:
     dependency: transitive
     description:
@@ -271,7 +271,7 @@ packages:
     source: hosted
     version: "1.1.1"
   frontend_server_client:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: frontend_server_client
       sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
@@ -570,10 +570,10 @@ packages:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   source_gen:
     dependency: transitive
     description:
@@ -658,26 +658,26 @@ packages:
     dependency: "direct main"
     description:
       name: test
-      sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"
+      sha256: "22eb7769bee38c7e032d532e8daa2e1cc901b799f603550a4db8f3a5f5173ea2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.8"
+    version: "1.25.12"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.4"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "12391302411737c176b0b5d6491f466b0dd56d4763e347b6714efbaa74d7953d"
+      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.8"
   test_html_builder:
     dependency: "direct dev"
     description:
@@ -698,10 +698,10 @@ packages:
     dependency: transitive
     description:
       name: transformer_utils
-      sha256: "664ff59612d12ed1c288f52e99a2ebbd203185843c824cc705319ea696272b61"
+      sha256: "2fffc3cd42cabc7ce6d4e4bab734b90f01404ae1fe85c32f17f570c4f24ec42c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.21"
+    version: "0.2.22"
   tuple:
     dependency: "direct main"
     description:
@@ -722,10 +722,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "15.0.0"
   w_common:
     dependency: transitive
     description:
@@ -738,10 +738,10 @@ packages:
     dependency: transitive
     description:
       name: w_flux
-      sha256: f44652c569b72de90c8edbce572f1b5a5e46c069481ca3416ec5a3c30607dfce
+      sha256: "2500ba30a908dc1d0cb1bb9ff6e1b27937eacd0b63ba145ad9b058fb1347eaa5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   watcher:
     dependency: "direct main"
     description:
@@ -758,14 +758,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: "9f187088ed104edd8662ca07af4b124465893caf063ba29758f97af57e61da8f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "3.0.1"
   webkit_inspection_protocol:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,50 +21,50 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: "22600aa1e926be775fa5fe7e6894e7fb3df9efda8891c73f70fb3262399a432d"
+      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.10"
+    version: "3.6.1"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.6.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   bazel_worker:
     dependency: transitive
     description:
       name: bazel_worker
-      sha256: "4eef19cc486c289e4b06c69d0f6f3192e85cc93c25d4d15d02afb205e388d2f0"
+      sha256: "57035594b87d9f5af99f1a80e1edf5411dadbdf5acfc4f90403e3849f57dd0f0"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   build:
     dependency: transitive
     description:
       name: build
-      sha256: "3fbda25365741f8251b39f3917fb3c8e286a96fd068a5a242e11c2012d495777"
+      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.1"
   build_config:
     dependency: transitive
     description:
@@ -77,58 +77,58 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "757153e5d9cd88253cb13f28c2fb55a537dc31fefd98137549895b5beb7c6169"
+      sha256: "79b2aef6ac2ed00046867ed354c88778c9c0f029df8a20fe10b5436826721ef9"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "4.0.2"
   build_modules:
     dependency: transitive
     description:
       name: build_modules
-      sha256: d02a5b40720692c8c4c385741afb1cc50b53f192a33fa5da1f2bdaec3ec6db3e
+      sha256: "403ba034d94f1a0f26362fe14fd83e9ff33644f5cbe879982920e3d209650b43"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.7"
+    version: "5.0.9"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "0713a05b0386bd97f9e63e78108805a4feca5898a4b821d6610857f10c91e975"
+      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.2"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: b0a8a7b8a76c493e85f1b84bffa0588859a06197863dba8c9036b15581fd9727
+      sha256: "028819cfb90051c6b5440c7e574d1896f8037e3c96cf17aaeb054c9311cfbf4d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.13"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "0671ad4162ed510b70d0eb4ad6354c249f8429cab4ae7a4cec86bbc2886eb76e"
+      sha256: f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.7+1"
+    version: "7.3.2"
   build_test:
     dependency: "direct dev"
     description:
       name: build_test
-      sha256: "178a9e8989cbd40b3104b88cb6ab8cbf6e3293d90b31ba44420745cba54730f1"
+      sha256: "260dbba934f41b0a42935e9cae1f5731b94f0c3e489dc97bcf8e281265aaa5ae"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   build_web_compilers:
     dependency: "direct dev"
     description:
       name: build_web_compilers
-      sha256: ee45348ba9c2dfd2e165c0adf69311970fa620c6669c345ab533e16d0d119e3d
+      sha256: e8d818410cc8b4dc96c4960ce0ab84fe3f2b0ca6576cc130fd7277b56eba9d68
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.7"
+    version: "4.0.11"
   built_collection:
     dependency: "direct main"
     description:
@@ -141,18 +141,18 @@ packages:
     dependency: "direct main"
     description:
       name: built_value
-      sha256: "2f17434bd5d52a26762043d6b43bb53b3acd029b4d9071a329f46d67ef297e6d"
+      sha256: c7913a9737ee4007efedaffc968c049fd0f3d0e49109e778edc10de9426005cb
       url: "https://pub.dev"
     source: hosted
-    version: "8.5.0"
+    version: "8.9.2"
   built_value_generator:
     dependency: "direct dev"
     description:
       name: built_value_generator
-      sha256: "4db7a90cb52abfe4ce0e55e0cfb68db85d65ca8d9bdf9d4f57a87fbaaebe3602"
+      sha256: bb06c5e9dbdbd35ed6de21520e2e5112582c964fa584e2a4bb59887fc7a169b0
       url: "https://pub.dev"
     source: hosted
-    version: "8.5.0"
+    version: "8.9.2"
   checked_yaml:
     dependency: transitive
     description:
@@ -165,26 +165,26 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "1be9be30396d7e4c0db42c35ea6ccd7cc6a1e19916b5dc64d6ac216b5544d677"
+      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "4.10.1"
   collection:
     dependency: "direct main"
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   color:
     dependency: "direct main"
     description:
@@ -197,34 +197,34 @@ packages:
     dependency: transitive
     description:
       name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      sha256: "595a29b55ce82d53398e1bcc2cba525d7bd7c59faeb2d2540e9d42c390cfeeeb"
+      sha256: "4b03e11f6d5b8f6e5bb5e9f7889a56fe6c5cbe942da5378ea4d4d7f73ef9dfe5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.4"
+    version: "1.11.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.6"
   csslib:
     dependency: transitive
     description:
       name: csslib
-      sha256: "706b5707578e0c1b4b7550f64078f0a0f19dec3f50a178ffae7006b0a9ca58fb"
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.2"
   dart_style:
     dependency: transitive
     description:
@@ -253,26 +253,26 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.1"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   frontend_server_client:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: frontend_server_client
-      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
@@ -285,26 +285,26 @@ packages:
     dependency: transitive
     description:
       name: graphs
-      sha256: aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   html:
     dependency: transitive
     description:
       name: html
-      sha256: "3a7812d5bcd2894edf53dfaf8cd640876cf6cef50a8f238745c8b8120ea74d3a"
+      sha256: "1fc58edeaec4307368c60d59b7e15b9d658b57d7f3125098b6294153c75337ec"
       url: "https://pub.dev"
     source: hosted
-    version: "0.15.4"
+    version: "0.15.5"
   http:
     dependency: "direct main"
     description:
       name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.6"
+    version: "1.2.2"
   http_multi_server:
     dependency: transitive
     description:
@@ -317,10 +317,10 @@ packages:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "76d306a1c3afb33fe82e2bbacad62a61f409b5634c915fceb0d799de1a913360"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.1"
   intl:
     dependency: transitive
     description:
@@ -349,26 +349,26 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.1"
+    version: "4.9.0"
   logging:
     dependency: transitive
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   memoize:
     dependency: transitive
     description:
@@ -381,18 +381,18 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   node_preamble:
     dependency: transitive
     description:
@@ -405,10 +405,10 @@ packages:
     dependency: "direct main"
     description:
       name: over_react
-      sha256: "50c77616a20ad5ab85de1ad76c9b2c733ad5883e1217116bddbf0c7f57db70a8"
+      sha256: "9052c0c979811bd7ff35a145bd79de0da6f6f107017909826ed24fc9ee83b990"
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.0"
+    version: "5.4.1"
   over_react_test:
     dependency: "direct dev"
     description:
@@ -429,18 +429,18 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.1"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      sha256: cb3798bef7fc021ac45b308f4b51208a152792445cce0448c9a4ba5879dd8750
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.0"
+    version: "6.0.2"
   platform_detect:
     dependency: "direct main"
     description:
@@ -449,14 +449,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
-  pointycastle:
-    dependency: transitive
-    description:
-      name: pointycastle
-      sha256: "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.7.3"
   pool:
     dependency: transitive
     description:
@@ -485,10 +477,10 @@ packages:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
+      sha256: c799b721d79eb6ee6fa56f00c04b472dcd44a30d258fac2174a6ec57302678f8
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.3.0"
   quiver:
     dependency: "direct main"
     description:
@@ -501,10 +493,10 @@ packages:
     dependency: "direct main"
     description:
       name: react
-      sha256: a0a249c5914c4de394ae14b33bf777a8dc378fd66743d17c1267a015b4d5504f
+      sha256: cebcf69d0366f72552672a0a034a75277b67711b4f1c2c71cd1d8d134fadf8c5
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.3"
+    version: "7.2.0"
   redux:
     dependency: "direct main"
     description:
@@ -541,10 +533,10 @@ packages:
     dependency: transitive
     description:
       name: shelf
-      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.2"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -557,10 +549,10 @@ packages:
     dependency: transitive
     description:
       name: shelf_static
-      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -573,18 +565,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "373f96cf5a8744bc9816c1ff41cf5391bbdbe3d7a96fe98c622b6738a8a7bd33"
+      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.5.0"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   source_maps:
     dependency: transitive
     description:
@@ -605,18 +597,18 @@ packages:
     dependency: "direct main"
     description:
       name: spreadsheet_decoder
-      sha256: "1678ea1aa88880b9d69dd979851d05d424f2f5f5426f6b93bbd99c9a8cd1bff5"
+      sha256: "1370af9802bf14c7bdd9f24609294bbba0dbe715413922ce8e927d6d37aeefc6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -637,10 +629,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "0bd04f5bb74fcd6ff0606a888a30e917af9bd52820b178eaa464beb11dca84b6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.0"
   term_glyph:
     dependency: transitive
     description:
@@ -653,26 +645,26 @@ packages:
     dependency: "direct main"
     description:
       name: test
-      sha256: "13b41f318e2a5751c3169137103b60c584297353d4b1761b66029bae6411fe46"
+      sha256: a1f7595805820fcc05e5c52e3a231aedd0b72972cb333e8c738a8b1239448b6f
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.3"
+    version: "1.24.9"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "99806e9e6d95c7b059b7a0fc08f07fc53fabe54a829497f0d9676299f1e8637e"
+      sha256: a757b14fc47507060a162cc2530d9a4a2f92f5100a952c7443b5cad5ef5b106a
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.3"
+    version: "0.5.9"
   test_html_builder:
     dependency: "direct dev"
     description:
@@ -709,26 +701,26 @@ packages:
     dependency: transitive
     description:
       name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: c538be99af830f478718b51630ec1b6bee5e74e52c8a802d328d9e71d35d2583
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "11.10.0"
+    version: "13.0.0"
   w_common:
     dependency: transitive
     description:
       name: w_common
-      sha256: dfed94b2a49ad68593c382cdd395f4b101c4ca4f866334db5c94522297d5cc28
+      sha256: "4daab34b1c414a2d3e3881ac53c473587b30961e0432acc4474e45dc5f48ea1e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.2.0"
   w_flux:
     dependency: transitive
     description:
@@ -738,37 +730,45 @@ packages:
     source: hosted
     version: "3.0.0"
   watcher:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: watcher
-      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: "58c6666b342a38816b2e7e50ed0f1e261959630becd4c879c4f26bfa14aa5a42"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.5"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   xml:
     dependency: "direct main"
     description:
       name: xml
-      sha256: "5bc72e1e45e941d825fd7468b9b4cc3b9327942649aeb6fc5cdbf135f0a86e84"
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.5.0"
   yaml:
     dependency: transitive
     description:
@@ -778,4 +778,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=2.19.6 <3.0.0"
+  dart: ">=3.5.0 <3.7.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
+      sha256: "45cfa8471b89fb6643fe9bf51bd7931a76b8f5ec2d65de4fb176dba8d4f22c77"
       url: "https://pub.dev"
     source: hosted
-    version: "61.0.0"
+    version: "73.0.0"
+  _macros:
+    dependency: transitive
+    description: dart
+    source: sdk
+    version: "0.3.2"
   analyzer:
     dependency: "direct main"
     description:
       name: analyzer
-      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
+      sha256: "4959fec185fe70cce007c57e9ab6983101dbe593d2bf8bbfb4453aaec0cf470a"
       url: "https://pub.dev"
     source: hosted
-    version: "5.13.0"
+    version: "6.8.0"
   archive:
     dependency: transitive
     description:
@@ -229,10 +234,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "1efa911ca7086affd35f463ca2fc1799584fb6aa89883cf0af8e3664d6a02d55"
+      sha256: "7856d364b589d1f08986e140938578ed36ed948581fbc3bc9aef1805039ac5ab"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.7"
   dialog:
     dependency: "direct main"
     description:
@@ -361,6 +366,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  macros:
+    dependency: transitive
+    description:
+      name: macros
+      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2-main.4"
   matcher:
     dependency: transitive
     description:
@@ -645,34 +658,34 @@ packages:
     dependency: "direct main"
     description:
       name: test
-      sha256: a1f7595805820fcc05e5c52e3a231aedd0b72972cb333e8c738a8b1239448b6f
+      sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.9"
+    version: "1.25.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.3"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: a757b14fc47507060a162cc2530d9a4a2f92f5100a952c7443b5cad5ef5b106a
+      sha256: "12391302411737c176b0b5d6491f466b0dd56d4763e347b6714efbaa74d7953d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.9"
+    version: "0.6.5"
   test_html_builder:
     dependency: "direct dev"
     description:
       name: test_html_builder
-      sha256: "280df18552af3c6940124ac380fe91862faf965bcdeed35f0eccc2f766665d30"
+      sha256: f5ff610bd16608eb046543e315b33cfe07ce339388b6e07258772e52a800d941
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.8"
   timing:
     dependency: transitive
     description:
@@ -741,18 +754,18 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "1.1.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "58c6666b342a38816b2e7e50ed0f1e261959630becd4c879c4f26bfa14aa5a42"
+      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.5"
+    version: "2.4.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A web-based scriptable cadnano (see https://cadnano.org/ for origin
 #author: David Doty <doty@ucdavis.edu>
 
 environment:
-  sdk: '>=2.19.6 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   analyzer: ^5.13.0
@@ -15,7 +15,7 @@ dependencies:
   dialog: ^0.8.0
   dnd: ^2.0.1
   js: ^0.6.7
-  http: ^0.13.6
+  http: ^1.2.2
   meta: ^1.15.0
   quiver: ^3.2.2
   path: ^1.8.3
@@ -25,14 +25,18 @@ dependencies:
   reselect: ^0.5.0
   over_react: ^5.3.0
   spreadsheet_decoder: ^2.2.0
-  test: ^1.24.3
+  test: ^1.24.9
   tuple: ^2.0.2
   xml: ^6.3.0
+  watcher: ^1.1.0
+
+dependency_overrides:
+  frontend_server_client: ^4.0.0
 
 dev_dependencies:
-  build_runner: ^2.3.3
-  build_test: ^2.2.1
-  build_web_compilers: ^3.2.7
+  build_runner: ^2.4.12
+  build_test: ^2.2.2
+  build_web_compilers: ^4.0.11
   built_value_generator: ^8.5.0
   over_react_test: ^3.0.0
   test_html_builder: ^3.0.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,9 +30,6 @@ dependencies:
   xml: ^6.3.0
   watcher: ^1.1.0
 
-dependency_overrides:
-  frontend_server_client: ^4.0.0
-
 dev_dependencies:
   build_runner: ^2.4.13
   build_test: ^2.2.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  analyzer: ^5.13.0
+  analyzer: ^6.8.0
   built_value: ^8.5.0
   built_collection: ^5.1.1
   collection: ^1.15.0-nullsafety.4
@@ -25,7 +25,7 @@ dependencies:
   reselect: ^0.5.0
   over_react: ^5.3.0
   spreadsheet_decoder: ^2.2.0
-  test: ^1.24.9
+  test: ^1.25.8
   tuple: ^2.0.2
   xml: ^6.3.0
   watcher: ^1.1.0
@@ -34,7 +34,7 @@ dependency_overrides:
   frontend_server_client: ^4.0.0
 
 dev_dependencies:
-  build_runner: ^2.4.12
+  build_runner: ^2.4.13
   build_test: ^2.2.2
   build_web_compilers: ^4.0.11
   built_value_generator: ^8.5.0

--- a/test/export_cadnano_v2_test.dart
+++ b/test/export_cadnano_v2_test.dart
@@ -129,9 +129,9 @@ main() {
           .cross(1)
           .move(-16)
           .as_scaffold()
-          // also assigns complement to strands other than scaf bound to it
+      // also assigns complement to strands other than scaf bound to it
           .with_sequence('AACGT' * 18)
-          // deletions and insertions added to design so they can be added to both strands on a helix
+      // deletions and insertions added to design so they can be added to both strands on a helix
           .add_deletion(0, 11)
           .add_deletion(0, 12)
           .add_deletion(0, 24)
@@ -303,8 +303,8 @@ main() {
         Helix(idx: 3, max_offset: 64, grid_position: GridPosition(19, 16), grid: Grid.square),
         Helix(idx: 2, max_offset: 64, grid_position: GridPosition(19, 17), grid: Grid.square),
       ];
-      var design = Design(helices: helices);
-      design = design.draw_strand(3, 24).to(8).cross(1, 24).to(8).commit();
+      var design = Design(helices: helices, grid: Grid.square);
+      design = design.draw_strand(3, 24).to(8).cross(1, 24).to(8).as_scaffold().commit();
       design = design.draw_strand(2, 50).to(24).cross(0, 50).to(24).commit();
 
       String output_json = to_cadnano_v2_json(design);
@@ -355,9 +355,9 @@ main() {
           .loopout(1, 3)
           .move(-16)
           .as_scaffold()
-          // also assigns complement to strands other than scaf bound to it
+      // also assigns complement to strands other than scaf bound to it
           .with_sequence('AACGT' * 18)
-          // deletions and insertions added to design so they can be added to both strands on a helix
+      // deletions and insertions added to design so they can be added to both strands on a helix
           .add_deletion(1, 20)
           .add_insertion(0, 14, 1)
           .add_insertion(0, 26, 2)

--- a/test/export_cadnano_v2_test.dart
+++ b/test/export_cadnano_v2_test.dart
@@ -129,9 +129,9 @@ main() {
           .cross(1)
           .move(-16)
           .as_scaffold()
-      // also assigns complement to strands other than scaf bound to it
+          // also assigns complement to strands other than scaf bound to it
           .with_sequence('AACGT' * 18)
-      // deletions and insertions added to design so they can be added to both strands on a helix
+          // deletions and insertions added to design so they can be added to both strands on a helix
           .add_deletion(0, 11)
           .add_deletion(0, 12)
           .add_deletion(0, 24)
@@ -355,9 +355,9 @@ main() {
           .loopout(1, 3)
           .move(-16)
           .as_scaffold()
-      // also assigns complement to strands other than scaf bound to it
+          // also assigns complement to strands other than scaf bound to it
           .with_sequence('AACGT' * 18)
-      // deletions and insertions added to design so they can be added to both strands on a helix
+          // deletions and insertions added to design so they can be added to both strands on a helix
           .add_deletion(1, 20)
           .add_insertion(0, 14, 1)
           .add_insertion(0, 26, 2)

--- a/test/reducer_test.dart
+++ b/test/reducer_test.dart
@@ -1608,7 +1608,7 @@ main() {
   String two_helices_json = '''
  {
   "version": "${constants.CURRENT_VERSION}",''' +
-      r''' 
+      r'''
   "grid": "square", 
   "helices": [ {"grid_position": [0, 0]}, {"grid_position": [0, 1]} ],
   "strands": [


### PR DESCRIPTION
## Description
This change adds support for Dart 3. However, there is some dependency overrides added to fix some issues. I have not yet found a way to solve this issue without adding the dependency override.

**Furthermore**, it is still failing `export_cadnano_v2_test.dart`.

## Related Issue
Fixes #990 

## Motivation and Context
This is to hopefully solve the long build times, but most importantly place the repository on the current dart dependency. This brings everything up to date.

## How Has This Been Tested?
This was tested on Windows 11, using **Dart 3.5.4**. The browsers I used were Firefox and Google Chrome. Since the JSONEncoder became a final class, we couldn't extend it anymore. We had to re-implement the JsonEncoder in our own way.