### PR TITLE
Fixes #988 - Fix Appearance of File -> Open

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,23 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "45cfa8471b89fb6643fe9bf51bd7931a76b8f5ec2d65de4fb176dba8d4f22c77"
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.dev"
     source: hosted
-    version: "73.0.0"
+    version: "76.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.2"
+    version: "0.3.3"
   analyzer:
     dependency: "direct main"
     description:
       name: analyzer
-      sha256: "4959fec185fe70cce007c57e9ab6983101dbe593d2bf8bbfb4453aaec0cf470a"
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.8.0"
+    version: "6.11.0"
   archive:
     dependency: transitive
     description:
@@ -370,10 +370,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2-main.4"
+    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:

--- a/web/scadnano-styles.css
+++ b/web/scadnano-styles.css
@@ -1108,7 +1108,7 @@ https://stackoverflow.com/questions/15138801/rotate-rectangle-around-its-own-cen
 .form-file-dropdown .custom-file-input + .custom-file-label {
     display: block;
     width: 100%;
-    padding: .25rem 1.5rem;
+    padding: 0;
     margin-bottom: 0%;
     /* Removes label browser default */
     clear: both;


### PR DESCRIPTION
## Description
I changed some CSS to be more in-line with what #988 was wanting to fix. However, it also ended up changing the "import cadnano v2" button as well. I looked elsewhere, and this appears to be the only item changing, but I am not sure if I am missing some other place this could have affected it.

## Related Issue
As for #988, "Open" was not lined up with "Save". You can view this by clicking `File` in the navigation bar.

## Motivation and Context
This fixes #988.

## How Has This Been Tested?
This was tested on both Firefox and Chrome, on Windows 11. This shouldn't affect the unit tests, and all unit tests have passed when updating the CSS. As for other ramifications, it appears as this only affects the "Open" and "Import cadnano v2" buttons in the File navigation menu. I have looked in other places, and it all otherwise looks identical to the current dev branch.

## Screenshots (if appropriate):
### File Menu (Before)
![image](https://github.com/user-attachments/assets/f0966147-ecc4-4128-baa4-d45dab4ea237)

### File Menu (After)
![image](https://github.com/user-attachments/assets/54a77264-65a5-4531-bce0-f5472f89c1ce)