### PR TITLE
Fixes #984 - Replace Tuples with Records

### DIFF
--- a/lib/src/middleware/helices_positions_set_based_on_crossovers.dart
+++ b/lib/src/middleware/helices_positions_set_based_on_crossovers.dart
@@ -214,7 +214,7 @@ Map<(int, int), List<(Address, Address)>> _get_addresses_of_selected_crossovers_
     var next_dom = strand.substrands[crossover.next_domain_idx] as Domain;
     var prev_idx = prev_dom.helix;
     var next_idx = next_dom.helix;
-    (int, int) pair_idxs =(prev_idx, next_idx);
+    (int, int) pair_idxs = (prev_idx, next_idx);
     (int, int) pair_idxs_rev = (next_idx, prev_idx);
 
     if (addresses_top_bot_crossovers.containsKey(pair_idxs) ||

--- a/lib/src/middleware/oxdna_export.dart
+++ b/lib/src/middleware/oxdna_export.dart
@@ -15,7 +15,6 @@ import 'package:scadnano/src/state/grid.dart';
 import 'package:scadnano/src/state/loopout.dart';
 import 'package:scadnano/src/state/position3d.dart';
 import 'package:scadnano/src/state/strand.dart';
-import 'package:tuple/tuple.dart';
 import '../state/app_state.dart';
 import '../actions/actions.dart' as actions;
 import '../state/helix.dart';
@@ -41,9 +40,9 @@ First select some strands, or choose Export🡒oxDNA to export all strands in th
     }
 
     if (action is actions.OxdnaExport) {
-      Tuple2<String, String> dat_top = to_oxdna_format(state.design, strands_to_export);
-      String dat = dat_top.item1;
-      String top = dat_top.item2;
+      (String, String) dat_top = to_oxdna_format(state.design, strands_to_export);
+      String dat = dat_top.$1;
+      String top = dat_top.$2;
 
       String default_filename = state.ui_state.loaded_filename;
       String default_filename_dat = path.setExtension(default_filename, '.dat');
@@ -147,11 +146,11 @@ String to_oxview_format(Design design, List<Strand> strands_to_export) {
       design.base_pairs_with_domain_strand(false, true, strands_to_export.toSet().build(), true);
   for (int helix in base_pairs_map.keys) {
     for (var offset_dom_strands in base_pairs_map[helix]!) {
-      int offset = offset_dom_strands.item1;
-      Domain domain1 = offset_dom_strands.item2;
-      Domain domain2 = offset_dom_strands.item3;
-      Strand sc_strand1 = offset_dom_strands.item4;
-      Strand sc_strand2 = offset_dom_strands.item5;
+      int offset = offset_dom_strands.$1;
+      Domain domain1 = offset_dom_strands.$2;
+      Domain domain2 = offset_dom_strands.$3;
+      Strand sc_strand1 = offset_dom_strands.$4;
+      Strand sc_strand2 = offset_dom_strands.$5;
       Map<String, dynamic> oxv_strand1 = oxview_strand_map[sc_strand1.id];
       Map<String, dynamic> oxv_strand2 = oxview_strand_map[sc_strand2.id];
       int d1 = sc_strand1.domain_offset_to_strand_dna_idx(domain1, offset, false);
@@ -188,9 +187,9 @@ String to_oxview_format(Design design, List<Strand> strands_to_export) {
   return content;
 }
 
-Tuple2<String, String> to_oxdna_format(Design design, [List<Strand>? strands_to_export = null]) {
+(String, String) to_oxdna_format(Design design, [List<Strand>? strands_to_export = null]) {
   OxdnaSystem system = convert_design_to_oxdna_system(design, strands_to_export);
-  Tuple2<String, String> dat_top = system.oxdna_output();
+  (String, String) dat_top = system.oxdna_output();
   return dat_top;
 }
 
@@ -313,7 +312,7 @@ class OxdnaSystem {
     }
   }
 
-  Tuple2<String, String> oxdna_output() {
+  (String, String) oxdna_output() {
     OxdnaVector bbox = compute_bounding_box();
 
     List<String> dat_list = [
@@ -353,14 +352,14 @@ class OxdnaSystem {
 
     top = '${nuc_count} ${strand_count}\n' + top;
 
-    return Tuple2<String, String>(dat, top);
+    return (dat, top);
   }
 }
 
 const NM_TO_OX_UNITS = 1.0 / 0.8518;
 
 // returns the origin, forward, and normal vectors of a helix
-Tuple3<OxdnaVector, OxdnaVector, OxdnaVector> oxdna_get_helix_vectors(Design design, Helix helix) {
+(OxdnaVector, OxdnaVector, OxdnaVector) oxdna_get_helix_vectors(Design design, Helix helix) {
   /*
   TODO: document functions/methods with docstrings
   :param helix:
@@ -420,7 +419,7 @@ Tuple3<OxdnaVector, OxdnaVector, OxdnaVector> oxdna_get_helix_vectors(Design des
 
   var origin = (position_in_helix_group_rotated + helix_group_offset) * NM_TO_OX_UNITS;
 
-  return Tuple3<OxdnaVector, OxdnaVector, OxdnaVector>(origin, forward, normal);
+  return (origin, forward, normal);
 }
 
 OxdnaSystem convert_design_to_oxdna_system(Design design, [List<Strand>? strands_to_export = null]) {
@@ -466,7 +465,7 @@ OxdnaSystem convert_design_to_oxdna_system(Design design, [List<Strand>? strands
   };
 
   for (var strand in strands_to_export) {
-    List<Tuple2<OxdnaStrand, bool>> strand_domains = [];
+    List<(OxdnaStrand, bool)> strand_domains = [];
     for (int ss_idx = 0; ss_idx < strand.substrands.length; ss_idx++) {
       var domain = strand.substrands[ss_idx];
       var ox_strand = OxdnaStrand();
@@ -482,9 +481,9 @@ OxdnaSystem convert_design_to_oxdna_system(Design design, [List<Strand>? strands
         var geometry = group.geometry ?? design.geometry;
         var step_rot = -360 / geometry.bases_per_turn;
         var origin_forward_normal = helix_vectors[helix.idx]!;
-        var origin = origin_forward_normal.item1;
-        var forward = origin_forward_normal.item2;
-        var normal = origin_forward_normal.item3;
+        var origin = origin_forward_normal.$1;
+        var forward = origin_forward_normal.$2;
+        var normal = origin_forward_normal.$3;
 
         if (!domain.forward) {
           normal = normal.rotate(-geometry.minor_groove_angle, forward);
@@ -538,7 +537,7 @@ OxdnaSystem convert_design_to_oxdna_system(Design design, [List<Strand>? strands
         if (!domain.forward) {
           ox_strand.nucleotides = List<OxdnaNucleotide>.from(ox_strand.nucleotides.reversed);
         }
-        strand_domains.add(Tuple2<OxdnaStrand, bool>(ox_strand, false));
+        strand_domains.add((ox_strand, false));
         // because we need to know the positions of nucleotides before and after the loopout
         // we temporarily store domain strands with a boolean that is true if it's a loopout
         // handle loopouts
@@ -553,7 +552,7 @@ OxdnaSystem convert_design_to_oxdna_system(Design design, [List<Strand>? strands
           var nuc = OxdnaNucleotide(center, normal, forward, base);
           ox_strand.nucleotides.add(nuc);
         }
-        strand_domains.add(Tuple2<OxdnaStrand, bool>(ox_strand, true));
+        strand_domains.add((ox_strand, true));
       } else if (domain is Extension) {
         bool is_5p = ss_idx == 0;
         var helix = design.helices[domain.adjacent_domain.helix]!;
@@ -567,7 +566,7 @@ OxdnaSystem convert_design_to_oxdna_system(Design design, [List<Strand>? strands
             helix_vectors: helix_vectors,
             mod_map: mod_map);
         ox_strand.nucleotides.addAll(nucleotides);
-        strand_domains.add(Tuple2<OxdnaStrand, bool>(ox_strand, false));
+        strand_domains.add((ox_strand, false));
       } else {
         throw AssertionError('unreachable');
       }
@@ -577,11 +576,11 @@ OxdnaSystem convert_design_to_oxdna_system(Design design, [List<Strand>? strands
     // process loopouts and join strands
     for (int i = 0; i < strand_domains.length; i++) {
       var dstrand_is_loopout = strand_domains[i];
-      var dstrand = dstrand_is_loopout.item1;
-      var is_loopout = dstrand_is_loopout.item2;
+      var dstrand = dstrand_is_loopout.$1;
+      var is_loopout = dstrand_is_loopout.$2;
       if (is_loopout) {
-        var prev_nuc = strand_domains[i - 1].item1.nucleotides.last;
-        var next_nuc = strand_domains[i + 1].item1.nucleotides.first;
+        var prev_nuc = strand_domains[i - 1].$1.nucleotides.last;
+        var next_nuc = strand_domains[i + 1].$1.nucleotides.first;
 
         int strand_length = dstrand.nucleotides.length;
 
@@ -610,7 +609,7 @@ List<OxdnaNucleotide> _compute_extension_nucleotides(
     required Geometry geometry,
     required Strand strand,
     required bool is_5p,
-    required Map<int, Tuple3<OxdnaVector, OxdnaVector, OxdnaVector>> helix_vectors,
+    required Map<int, (OxdnaVector, OxdnaVector, OxdnaVector)> helix_vectors,
     required Map<int, List<int>> mod_map}) {
   var step_rot = -360 / geometry.bases_per_turn;
 
@@ -619,9 +618,9 @@ List<OxdnaNucleotide> _compute_extension_nucleotides(
   var offset = is_5p ? adj_dom.offset_5p : adj_dom.offset_3p; // offset of attached end of domain
 
   var origin_forward_normal = helix_vectors[adj_dom.helix]!;
-  var origin_ = origin_forward_normal.item1;
-  var forward = origin_forward_normal.item2;
-  var normal = origin_forward_normal.item3;
+  var origin_ = origin_forward_normal.$1;
+  var forward = origin_forward_normal.$2;
+  var normal = origin_forward_normal.$3;
 
   if (!adj_dom.forward) {
     normal = normal.rotate(-geometry.minor_groove_angle, forward);

--- a/lib/src/middleware/oxview_update_view.dart
+++ b/lib/src/middleware/oxview_update_view.dart
@@ -17,7 +17,6 @@ import 'package:scadnano/src/state/grid.dart';
 import 'package:scadnano/src/state/loopout.dart';
 import 'package:scadnano/src/state/position3d.dart';
 import 'package:scadnano/src/state/strand.dart';
-import 'package:tuple/tuple.dart';
 import '../state/app_state.dart';
 import '../actions/actions.dart' as actions;
 import '../state/helix.dart';
@@ -66,9 +65,9 @@ void update_oxview_view(Design design, [IFrameElement? frame = null]) {
   List<Strand> strands_to_export = design.strands.toList();
 
   // String content = to_oxview_format(design, strands_to_export);
-  Tuple2<String, String> dat_top = to_oxdna_format(design, strands_to_export);
-  String dat = dat_top.item1;
-  String top = dat_top.item2;
+  (String, String) dat_top = to_oxdna_format(design, strands_to_export);
+  String dat = dat_top.$1;
+  String top = dat_top.$2;
 
   Blob blob_dat = new Blob([dat], blob_type_to_string(BlobType.text));
   Blob blob_top = new Blob([top], blob_type_to_string(BlobType.text));

--- a/lib/src/middleware/reselect_moved_dna_extension_ends.dart
+++ b/lib/src/middleware/reselect_moved_dna_extension_ends.dart
@@ -2,7 +2,6 @@ import 'package:react/react.dart';
 import 'package:redux/redux.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:scadnano/src/state/extension.dart';
-import 'package:tuple/tuple.dart';
 
 import '../state/domain.dart';
 import '../state/dna_end.dart';

--- a/lib/src/middleware/selections_intersect_box_compute.dart
+++ b/lib/src/middleware/selections_intersect_box_compute.dart
@@ -5,7 +5,6 @@ import 'dart:svg' as svg;
 import 'package:built_collection/built_collection.dart';
 import 'package:redux/redux.dart';
 import 'package:scadnano/src/state/selection_rope.dart';
-import 'package:tuple/tuple.dart';
 
 import '../state/select_mode.dart';
 import '../state/selection_box.dart';

--- a/lib/src/middleware/system_clipboard.dart
+++ b/lib/src/middleware/system_clipboard.dart
@@ -118,8 +118,8 @@ bool paste_is_impossible_from_clipboard(String clipboard_content, bool in_browse
   var strands_and_helices_view_order = parse_strands_and_helices_view_order_from_clipboard(clipboard_content);
   if (strands_and_helices_view_order == null) return true;
 
-  List<Strand> strands = strands_and_helices_view_order.item1;
-  List<int>? helices_view_order = strands_and_helices_view_order.item2;
+  List<Strand> strands = strands_and_helices_view_order.$1;
+  List<int>? helices_view_order = strands_and_helices_view_order.$2;
 
   if (strands.isEmpty) return true;
 

--- a/lib/src/reducers/app_ui_state_reducer.dart
+++ b/lib/src/reducers/app_ui_state_reducer.dart
@@ -12,7 +12,6 @@ import 'package:scadnano/src/state/strand.dart';
 import 'package:scadnano/src/state/copy_info.dart';
 import 'package:scadnano/src/state/substrand.dart';
 import 'package:scadnano/src/util.dart';
-import 'package:tuple/tuple.dart';
 import '../reducers/context_menu_reducer.dart';
 import '../state/example_designs.dart';
 import '../state/grid_position.dart';

--- a/lib/src/reducers/assign_or_remove_dna_reducer.dart
+++ b/lib/src/reducers/assign_or_remove_dna_reducer.dart
@@ -4,7 +4,6 @@ import '../state/domain.dart';
 import '../state/design.dart';
 import '../state/loopout.dart';
 import '../state/substrand.dart';
-import 'package:tuple/tuple.dart';
 
 import '../state/strand.dart';
 import '../state/app_state.dart';
@@ -99,11 +98,11 @@ BuiltList<Strand> assign_dna_reducer(BuiltList<Strand> strands, AppState state, 
 }
 
 // Lexicographically compare (start,end) overlap coordinates of o1 and o2.
-int compare_overlap(Tuple2<Tuple2<int, int>, Domain> o1, Tuple2<Tuple2<int, int>, Domain> o2) {
-  int o1_start = o1.item1.item1;
-  int o1_end = o1.item1.item2;
-  int o2_start = o2.item1.item1;
-  int o2_end = o2.item1.item2;
+int compare_overlap(((int, int), Domain) o1, ((int, int), Domain) o2) {
+  int o1_start = o1.$1.$1;
+  int o1_end = o1.$1.$2;
+  int o2_start = o2.$1.$1;
+  int o2_end = o2.$1.$2;
   if (o1_start != o2_start) {
     return o1_start - o2_start;
   } else {
@@ -165,11 +164,11 @@ String compute_dna_complement_from(
 
       int helix_idx = domain_to.helix;
       List<Domain> domains_on_helix_from = strand_from.domains_on_helix[helix_idx]?.toList() ?? [];
-      List<Tuple2<Tuple2<int, int>, Domain>> overlaps = [];
+      List<((int, int), Domain)> overlaps = [];
       for (var domain_from in domains_on_helix_from) {
         if (domain_to != domain_from && domain_to.overlaps(domain_from)) {
-          Tuple2<int, int> overlap = domain_to.compute_overlap(domain_from)!;
-          overlaps.add(Tuple2<Tuple2<int, int>, Domain>(overlap, domain_from));
+          (int, int) overlap = domain_to.compute_overlap(domain_from)!;
+          overlaps.add((overlap, domain_from));
         }
       }
       overlaps.sort(compare_overlap);
@@ -178,9 +177,9 @@ String compute_dna_complement_from(
       int start_idx = domain_to.start;
       // repeatedly insert wildcards into gaps, then reverse WC complement
       for (var overlap in overlaps) {
-        int overlap_left = overlap.item1.item1;
-        int overlap_right = overlap.item1.item2;
-        Domain substrand_from = overlap.item2;
+        int overlap_left = overlap.$1.$1;
+        int overlap_right = overlap.$1.$2;
+        Domain substrand_from = overlap.$2;
         // wildcards = DNA_base_wildcard * (overlap_left - start_idx)
         int num_wildcard_bases = domain_to.dna_length_in(start_idx, overlap_left - 1);
         String wildcards = constants.DNA_BASE_WILDCARD * num_wildcard_bases;

--- a/lib/src/reducers/insertion_deletion_reducer.dart
+++ b/lib/src/reducers/insertion_deletion_reducer.dart
@@ -1,7 +1,6 @@
 import 'package:built_collection/built_collection.dart';
 import 'package:redux/redux.dart';
 import 'package:scadnano/src/state/app_state.dart';
-import 'package:tuple/tuple.dart';
 import '../actions/actions.dart' as actions;
 import '../state/domain.dart';
 import '../state/strand.dart';

--- a/lib/src/reducers/nick_ligate_join_by_crossover_reducers.dart
+++ b/lib/src/reducers/nick_ligate_join_by_crossover_reducers.dart
@@ -5,7 +5,6 @@ import 'package:react/react.dart';
 import 'package:scadnano/src/reducers/change_loopout_ext_properties.dart';
 import 'package:scadnano/src/state/linker.dart';
 import 'package:scadnano/src/state/potential_crossover.dart';
-import 'package:tuple/tuple.dart';
 
 import '../state/crossover.dart';
 import '../state/design.dart';
@@ -426,15 +425,15 @@ BuiltList<Strand> ligate_reducer(BuiltList<Strand> strands, AppState state, acti
 
 BuiltList<Strand> join_strands_by_multiple_crossovers_reducer(
     BuiltList<Strand> strands, AppState state, actions.JoinStrandsByMultipleCrossovers action) {
-  List<Tuple2<DNAEnd, DNAEnd>> end_pairs =
+  List<(DNAEnd, DNAEnd)> end_pairs =
       find_end_pairs_to_connect(state.design, state.ui_state.selectables_store.selected_dna_ends.toList());
 
   // build up list of addresses; these will stay the same even as the strands change as we add Crossovers
   List<Address> addresses_from = [];
   List<Address> addresses_to = [];
   for (var end_pair in end_pairs) {
-    var end1 = end_pair.item1;
-    var end2 = end_pair.item2;
+    var end1 = end_pair.$1;
+    var end2 = end_pair.$2;
     var end_from = end1.is_3p ? end1 : end2;
     var end_to = end1.is_3p ? end2 : end1;
     addresses_from.add(state.design.end_to_address[end_from]!);
@@ -468,7 +467,7 @@ Strand? _strand_with_end_address(Iterable<Strand> strands, Address address, bool
 
 /// find which pairs of ends among [selected_ends] to connect by Crossovers, and dispatch BatchAction
 /// to connect them
-List<Tuple2<DNAEnd, DNAEnd>> find_end_pairs_to_connect(Design design, List<DNAEnd> selected_ends) {
+List<(DNAEnd, DNAEnd)> find_end_pairs_to_connect(Design design, List<DNAEnd> selected_ends) {
   Map<DNAEnd, Domain> all_domains = {for (var end in selected_ends) end: design.end_to_domain[end]!};
 
   // group according to HelixGroups
@@ -485,7 +484,7 @@ List<Tuple2<DNAEnd, DNAEnd>> find_end_pairs_to_connect(Design design, List<DNAEn
   }
 
   // find pairs of ends to connect
-  List<Tuple2<DNAEnd, DNAEnd>> end_pairs_to_connect = [];
+  List<(DNAEnd, DNAEnd)> end_pairs_to_connect = [];
   for (var group_name in design.groups.keys) {
     // BuiltList<int> helices_view_order = design.groups[group_name].helices_view_order;
     BuiltMap<int, int> helices_view_order_inverse = design.groups[group_name]!.helices_view_order_inverse;
@@ -503,7 +502,7 @@ List<Tuple2<DNAEnd, DNAEnd>> find_end_pairs_to_connect(Design design, List<DNAEn
 
 /// find end pairs to connect according to algorithm described here:
 /// https://github.com/UC-Davis-molecular-computing/scadnano/issues/581
-List<Tuple2<DNAEnd, DNAEnd>> find_end_pairs_to_connect_in_group(
+List<(DNAEnd, DNAEnd)> find_end_pairs_to_connect_in_group(
     List<DNAEnd> ends, Map<DNAEnd, Domain> domains_by_end, BuiltMap<int, int> helices_view_order_inverse) {
   /// sort by helix, then by forward/reverse, then by offset
   ends.sort((DNAEnd end1, DNAEnd end2) {
@@ -532,7 +531,7 @@ List<Tuple2<DNAEnd, DNAEnd>> find_end_pairs_to_connect_in_group(
     ends_by_offset[end.offset_inclusive]!.add(end);
   }
 
-  List<Tuple2<DNAEnd, DNAEnd>> end_pairs = [];
+  List<(DNAEnd, DNAEnd)> end_pairs = [];
 
   for (int offset in ends_by_offset.keys) {
     // remember which ends have been paired with this offset, so we don't pick any twice
@@ -545,7 +544,7 @@ List<Tuple2<DNAEnd, DNAEnd>> find_end_pairs_to_connect_in_group(
       }
       var end2 = find_paired_end(end1, i + 1, ends_with_offset, already_chosen_ends, domains_by_end);
       if (end2 != null) {
-        var end_pair = Tuple2<DNAEnd, DNAEnd>(end1, end2);
+        (DNAEnd, DNAEnd) end_pair = (end1, end2);
         end_pairs.add(end_pair);
         already_chosen_ends.add(end1);
         already_chosen_ends.add(end2);

--- a/lib/src/reducers/strands_copy_info_reducer.dart
+++ b/lib/src/reducers/strands_copy_info_reducer.dart
@@ -3,7 +3,6 @@ import 'dart:html';
 
 import 'package:built_collection/built_collection.dart';
 import 'package:scadnano/src/state/modification.dart';
-import 'package:tuple/tuple.dart';
 
 import '../state/copy_info.dart';
 import '../state/strands_move.dart';
@@ -40,8 +39,8 @@ CopyInfo? manual_paste_initiate_reducer(CopyInfo? _, AppState state, actions.Man
     return null;
   }
 
-  List<Strand> strands = strands_and_helices_view_order.item1;
-  List<int>? helices_view_order = strands_and_helices_view_order.item2;
+  List<Strand> strands = strands_and_helices_view_order.$1;
+  List<int>? helices_view_order = strands_and_helices_view_order.$2;
 
   if (strands.isEmpty) return null;
   // indicates helices came from more than one HelixGroup, so no way to paste
@@ -62,8 +61,8 @@ CopyInfo? autopaste_initiate_reducer(CopyInfo? copy_info, AppState state, action
     return null;
   }
 
-  List<Strand> strands = strands_and_helices_view_order.item1;
-  List<int>? helices_view_order = strands_and_helices_view_order.item2;
+  List<Strand> strands = strands_and_helices_view_order.$1;
+  List<int>? helices_view_order = strands_and_helices_view_order.$2;
 
   if (strands.isEmpty) return null;
   // indicates helices came from more than one HelixGroup, so no way to paste
@@ -79,7 +78,7 @@ CopyInfo? autopaste_initiate_reducer(CopyInfo? copy_info, AppState state, action
 }
 
 /// returns null on JSON decode error
-Tuple2<List<Strand>, List<int>?>? parse_strands_and_helices_view_order_from_clipboard(
+(List<Strand>, List<int>?)? parse_strands_and_helices_view_order_from_clipboard(
     String clipboard_content) {
   String error_msg = 'no strand info found on system clipboard, so nothing to paste; '
       'content of system clipboard: "${clipboard_content}"';
@@ -155,7 +154,7 @@ Tuple2<List<Strand>, List<int>?>? parse_strands_and_helices_view_order_from_clip
     strands.add(strand);
   }
 
-  return Tuple2<List<Strand>, List<int>?>(strands, helices_view_order);
+  return (strands, helices_view_order);
 }
 
 // need to pass in helices_view_order from clipboard since these strands may be from a different design

--- a/lib/src/reducers/strands_copy_info_reducer.dart
+++ b/lib/src/reducers/strands_copy_info_reducer.dart
@@ -78,8 +78,7 @@ CopyInfo? autopaste_initiate_reducer(CopyInfo? copy_info, AppState state, action
 }
 
 /// returns null on JSON decode error
-(List<Strand>, List<int>?)? parse_strands_and_helices_view_order_from_clipboard(
-    String clipboard_content) {
+(List<Strand>, List<int>?)? parse_strands_and_helices_view_order_from_clipboard(String clipboard_content) {
   String error_msg = 'no strand info found on system clipboard, so nothing to paste; '
       'content of system clipboard: "${clipboard_content}"';
 

--- a/lib/src/reducers/strands_reducer.dart
+++ b/lib/src/reducers/strands_reducer.dart
@@ -9,7 +9,6 @@ import 'package:scadnano/src/state/extension.dart';
 import 'package:scadnano/src/state/loopout.dart';
 import 'package:scadnano/src/state/modification.dart';
 import 'package:scadnano/src/state/selectable.dart';
-import 'package:tuple/tuple.dart';
 
 import 'assign_domain_names_reducer.dart';
 import 'strands_move_reducer.dart' as strands_move_reducer;
@@ -363,8 +362,8 @@ BuiltList<Strand> strands_dna_ends_move_commit_reducer(
   for (var strand in strands_affected) {
     int strand_idx = strands.indexOf(strand);
     var ret = single_strand_dna_ends_commit_stop_reducer(strand, move, state.design);
-    strand = ret.item1;
-    records.addAll(ret.item2);
+    strand = ret.$1;
+    records.addAll(ret.$2);
     strand = strand.initialize();
     strands_builder[strand_idx] = strand;
   }
@@ -418,8 +417,8 @@ BuiltList<Strand> strands_dna_extensions_move_commit_reducer(
         geometry);
 
     Extension ext_new = extension.rebuild((b) => b
-      ..display_length = length_and_angle.item1
-      ..display_angle = length_and_angle.item2);
+      ..display_length = length_and_angle.$1
+      ..display_angle = length_and_angle.$2);
 
     substrands_builder[substrand_idx] = ext_new;
     strand = strand.rebuild((s) => s..substrands = substrands_builder);
@@ -439,7 +438,7 @@ class InsertionDeletionRecord {
       'InsertionDeletionRecord(offset=${offset}, strand_idx=$strand_idx, substrand_idx=$substrand_idx)';
 }
 
-Tuple2<Strand, List<InsertionDeletionRecord>> single_strand_dna_ends_commit_stop_reducer(
+(Strand, List<InsertionDeletionRecord>) single_strand_dna_ends_commit_stop_reducer(
     Strand strand, DNAEndsMove all_move, Design design) {
   List<InsertionDeletionRecord> records = [];
   List<Substrand> substrands = strand.substrands.toList();
@@ -487,7 +486,7 @@ Tuple2<Strand, List<InsertionDeletionRecord>> single_strand_dna_ends_commit_stop
     substrands[i] = new_substrand;
   }
   strand = strand.rebuild((b) => b..substrands.replace(substrands));
-  return Tuple2<Strand, List<InsertionDeletionRecord>>(strand, records);
+  return (strand, records);
 }
 
 List<int> get_remaining_deletions(Domain substrand, int new_offset, DNAEnd dnaend) => substrand.deletions

--- a/lib/src/serializers.dart
+++ b/lib/src/serializers.dart
@@ -9,7 +9,6 @@ import 'package:scadnano/src/dna_file_type.dart';
 import 'package:scadnano/src/state/base_pair_display_type.dart';
 import 'package:scadnano/src/state/dna_extensions_move.dart';
 import 'package:scadnano/src/state/undo_redo.dart';
-import 'package:tuple/tuple.dart';
 
 import 'state/dna_assign_options.dart';
 import 'state/domains_move.dart';

--- a/lib/src/state/app_ui_state.dart
+++ b/lib/src/state/app_ui_state.dart
@@ -7,7 +7,6 @@ import 'package:built_value/built_value.dart';
 import 'package:scadnano/src/state/design_side_rotation_data.dart';
 import 'package:scadnano/src/state/modification.dart';
 import 'package:scadnano/src/state/copy_info.dart';
-import 'package:tuple/tuple.dart';
 import '../actions/actions.dart' as actions;
 import '../state/local_storage_design_choice.dart';
 

--- a/lib/src/state/design.dart
+++ b/lib/src/state/design.dart
@@ -2235,8 +2235,8 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
                       base1 == constants.DNA_BASE_WILDCARD ||
                       base2 == constants.DNA_BASE_WILDCARD)) ||
               util.reverse_complementary(base1, base2, allow_wildcard: true)) {
-            offsets_and_domain_strand.add((
-                offset, dom1, dom2, this.substrand_to_strand[dom1]!, this.substrand_to_strand[dom2]!));
+            offsets_and_domain_strand
+                .add((offset, dom1, dom2, this.substrand_to_strand[dom1]!, this.substrand_to_strand[dom2]!));
           }
         }
       }

--- a/lib/src/state/domain.dart
+++ b/lib/src/state/domain.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:color/color.dart';
-import 'package:tuple/tuple.dart';
 import 'package:built_collection/built_collection.dart';
 
 import 'select_mode.dart';
@@ -551,14 +550,14 @@ abstract class Domain
         this.compute_overlap(other) != null);
   }
 
-  Tuple2<int, int>? compute_overlap(Domain other) {
+  (int, int)? compute_overlap(Domain other) {
     int overlap_start = max(this.start, other.start);
     int overlap_end = min(this.end, other.end);
     if (overlap_start >= overlap_end) {
       // overlap is empty
       return null;
     }
-    return Tuple2<int, int>(overlap_start, overlap_end);
+    return (overlap_start, overlap_end);
   }
 
   bool contains_insertion_at(int offset) {

--- a/lib/src/state/export_dna_format.dart
+++ b/lib/src/state/export_dna_format.dart
@@ -6,7 +6,6 @@ import 'package:built_value/serializer.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:scadnano/src/view/menu_form_file.dart';
 import 'package:spreadsheet_decoder/spreadsheet_decoder.dart';
-import 'package:tuple/tuple.dart';
 
 import '../util.dart' as util;
 import 'strand.dart';
@@ -16,7 +15,7 @@ part 'export_dna_format.g.dart';
 
 typedef StrandComparison = int Function(Strand s1, Strand s2);
 
-Tuple2<int, int> strand_helix_offset_key(Strand strand, StrandOrder strand_order, bool column_major) {
+(int, int) strand_helix_offset_key(Strand strand, StrandOrder strand_order, bool column_major) {
   int helix_idx;
   int offset;
   if (strand_order == StrandOrder.five_prime) {
@@ -59,7 +58,7 @@ Tuple2<int, int> strand_helix_offset_key(Strand strand, StrandOrder strand_order
   } else {
     throw ArgumentError('${strand_order} is not a valid StrandOrder');
   }
-  return Tuple2<int, int>(helix_idx, offset);
+  return (helix_idx, offset);
 }
 
 /// Returns comparison function that can be used to sort Strands
@@ -67,25 +66,25 @@ StrandComparison strands_comparison_function(StrandOrder strand_order, bool colu
   int compare(Strand strand1, Strand strand2) {
     var helix_offset1 = strand_helix_offset_key(strand1, strand_order, column_major);
     var helix_offset2 = strand_helix_offset_key(strand2, strand_order, column_major);
-    int helix_idx1 = helix_offset1.item1;
-    int offset1 = helix_offset1.item2;
-    int helix_idx2 = helix_offset2.item1;
-    int offset2 = helix_offset2.item2;
+    int helix_idx1 = helix_offset1.$1;
+    int offset1 = helix_offset1.$2;
+    int helix_idx2 = helix_offset2.$1;
+    int offset2 = helix_offset2.$2;
 
-    var tuple1;
-    var tuple2;
+    (int, int) tuple1;
+    (int, int) tuple2;
     if (column_major) {
-      tuple1 = Tuple2<int, int>(offset1, helix_idx1);
-      tuple2 = Tuple2<int, int>(offset2, helix_idx2);
+      tuple1 = (offset1, helix_idx1);
+      tuple2 = (offset2, helix_idx2);
     } else {
-      tuple1 = Tuple2<int, int>(helix_idx1, offset1);
-      tuple2 = Tuple2<int, int>(helix_idx2, offset2);
+      tuple1 = (helix_idx1, offset1);
+      tuple2 = (helix_idx2, offset2);
     }
 
-    if (tuple1.item1 != tuple2.item1) {
-      return tuple1.item1 - tuple2.item1;
+    if (tuple1.$1 != tuple2.$1) {
+      return tuple1.$1 - tuple2.$1;
     } else {
-      return tuple1.item2 - tuple2.item2;
+      return tuple1.$2 - tuple2.$2;
     }
   }
 

--- a/lib/src/state/extension.dart
+++ b/lib/src/state/extension.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:color/color.dart';
-import 'package:tuple/tuple.dart';
 import 'package:built_collection/built_collection.dart';
 
 import 'select_mode.dart';

--- a/lib/src/state/helix.dart
+++ b/lib/src/state/helix.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:built_value/serializer.dart';
 import 'package:built_collection/built_collection.dart';
-import 'package:tuple/tuple.dart';
 import '../state/design.dart';
 import '../state/position3d.dart';
 import '../state/unused_fields.dart';
@@ -408,12 +407,12 @@ abstract class Helix with BuiltJsonSerializable, UnusedFields implements Built<H
 
   double compute_relaxed_roll_delta(
       BuiltMap<int, Helix> helices, BuiltList<Address> crossover_addresses, Geometry geometry) {
-    List<Tuple2<double, double>> angles = [];
+    List<(double, double)> angles = [];
     for (var address in crossover_addresses) {
       var other_helix = helices[address.helix_idx]!;
       var angle_of_other_helix = util.angle_from_helix_to_helix(this, other_helix, geometry);
       var crossover_angle = this.backbone_angle_at_offset(address.offset, address.forward, geometry);
-      var relative_angle = Tuple2<double, double>(crossover_angle, angle_of_other_helix);
+      (double, double) relative_angle = (crossover_angle, angle_of_other_helix);
       angles.add(relative_angle);
     }
     var angle = util.minimum_strain_angle(angles);

--- a/lib/src/state/strand.dart
+++ b/lib/src/state/strand.dart
@@ -3,7 +3,6 @@ import 'package:color/color.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:react/react.dart';
-import 'package:tuple/tuple.dart';
 
 import 'address.dart';
 import 'helix.dart';
@@ -502,7 +501,7 @@ abstract class Strand
     for (var mod_idx in modifications_int.keys) {
       var mod = modifications_int[mod_idx]!;
       var ss_and_idx = _substrand_of_dna_idx(mod_idx);
-      Substrand ss = ss_and_idx.item1;
+      Substrand ss = ss_and_idx.$1;
       int ss_idx = index_of_substrand(ss);
       mods[ss_idx][mod_idx] = mod;
     }
@@ -535,8 +534,8 @@ abstract class Strand
     for (var mod_idx in modifications_int.keys) {
       var mod = modifications_int[mod_idx]!;
       var ss_and_idx = _substrand_of_dna_idx(mod_idx);
-      Substrand ss = ss_and_idx.item1;
-      int idx_within_ss = ss_and_idx.item2;
+      Substrand ss = ss_and_idx.$1;
+      int idx_within_ss = ss_and_idx.$2;
       mods[ss]![idx_within_ss] = mod;
     }
 
@@ -547,7 +546,7 @@ abstract class Strand
     return mods_built.build();
   }
 
-  Tuple2<Substrand, int> _substrand_of_dna_idx(int dna_idx) {
+  (Substrand, int) _substrand_of_dna_idx(int dna_idx) {
     if (dna_idx < 0) {
       throw ArgumentError('dna_idx cannot be negative but is ${dna_idx}');
     }
@@ -559,7 +558,7 @@ abstract class Strand
     for (var ss in substrands) {
       int dna_idx_cur_ss_end = dna_idx_cur_ss_start + ss.dna_length();
       if (dna_idx_cur_ss_start <= dna_idx && dna_idx < dna_idx_cur_ss_end) {
-        return Tuple2<Substrand, int>(ss, dna_idx - dna_idx_cur_ss_start);
+        return (ss, dna_idx - dna_idx_cur_ss_start);
       }
       dna_idx_cur_ss_start = dna_idx_cur_ss_end;
     }
@@ -1023,11 +1022,11 @@ abstract class Strand
   /// If this and other are ligatable (they have a pair of 5'/3' ends adjacent)
   /// return the two [DNAEnd]s that can be ligated, in other (this.end, other.end),
   /// otherwise return null.
-  Tuple2<DNAEnd, DNAEnd>? ligatable_ends_with(Strand other) {
+  (DNAEnd, DNAEnd)? ligatable_ends_with(Strand other) {
     if (_ligatable_3p_to_5p_of(other)) {
-      return Tuple2<DNAEnd, DNAEnd>(dnaend_3p, other.dnaend_5p);
+      return (dnaend_3p, other.dnaend_5p);
     } else if (_ligatable_5p_to_3p_of(other)) {
-      return Tuple2<DNAEnd, DNAEnd>(dnaend_5p, other.dnaend_3p);
+      return (dnaend_5p, other.dnaend_3p);
     } else {
       return null;
     }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -31,7 +31,6 @@ import 'state/domains_move.dart';
 import 'state/group.dart';
 import 'state/strands_move.dart';
 import 'view/design.dart';
-import 'package:tuple/tuple.dart';
 import 'package:quiver/iterables.dart' as quiver;
 
 import 'app.dart';
@@ -393,14 +392,14 @@ Map<int, Helix> helices_list_to_map(List<Helix> helices) => {for (var helix in h
 dynamic unwrap_from_noindent(dynamic obj) => obj is NoIndent ? obj.value : obj;
 
 /// Finds two indices of elements in list that repeat, returning null if all elements are distinct.
-Tuple2<int, int>? repeated_element_indices<T>(List<T> list) {
+(int, int)? repeated_element_indices<T>(List<T> list) {
   Map<T, int> elt_to_idx = {};
   // should take time n log n; we don't do linear search for indices until we know which element repeats
   for (int i2 = 0; i2 < list.length; i2++) {
     T elt = list[i2];
     int? i1 = elt_to_idx[elt];
     if (i1 != null) {
-      return Tuple2<int, int>(i1, i2);
+      return (i1, i2);
     }
     elt_to_idx[elt] = i2;
   }
@@ -1764,7 +1763,7 @@ Point<double> compute_extension_free_end_svg(
   return ext_end_svg;
 }
 
-Tuple2<double, double> compute_extension_length_and_angle_from_point(Point<double> current_mouse_point,
+(double, double) compute_extension_length_and_angle_from_point(Point<double> current_mouse_point,
     Point<double> attached_end_svg, Extension ext, Domain adjacent_domain, Geometry geometry) {
   num new_x = current_mouse_point.x;
   num new_y = current_mouse_point.y;
@@ -1780,7 +1779,7 @@ Tuple2<double, double> compute_extension_length_and_angle_from_point(Point<doubl
   if ((adjacent_domain.forward && ext.is_5p) || (!adjacent_domain.forward && !ext.is_5p)) {
     angle_radians = pi - angle_radians;
   }
-  return Tuple2(display_length, angle_radians * 180 / pi);
+  return (display_length, angle_radians * 180 / pi);
 }
 
 update_mouseover(SyntheticMouseEvent event_syn, Helix helix, Point<double> helix_svg_position) {
@@ -1917,8 +1916,8 @@ double angle_from_helix_to_helix(Helix helix, Helix other_helix, Geometry geomet
 //     angle :math:`\theta` by which to rotate all angles :math:`\theta_i`
 //     (but not changing any "zero angle" :math:`\mu_i`)
 //     such that :math:`\sum_i [(\theta + \theta_i) - \mu_i]^2` is minimized.
-double minimum_strain_angle(List<Tuple2<double, double>> relative_angles) {
-  var adjusted_angles = [for (var angle in relative_angles) angle.item1 - angle.item2];
+double minimum_strain_angle(List<(double, double)> relative_angles) {
+  var adjusted_angles = [for (var angle in relative_angles) angle.$1 - angle.$2];
   var ave_angle = average_angle(adjusted_angles);
   var min_strain_angle = -ave_angle;
   min_strain_angle %= 360;

--- a/lib/src/view/design_main_dna_sequence.dart
+++ b/lib/src/view/design_main_dna_sequence.dart
@@ -5,7 +5,6 @@ import 'package:built_collection/built_collection.dart';
 import 'package:platform_detect/platform_detect.dart';
 import 'package:scadnano/src/state/group.dart';
 import 'package:scadnano/src/view/transform_by_helix_group.dart';
-import 'package:tuple/tuple.dart';
 
 import '../state/helix.dart';
 import 'package:scadnano/src/state/geometry.dart';
@@ -165,9 +164,9 @@ class DesignMainDNASequenceComponent extends UiComponent2<DesignMainDNASequenceP
     var start_offset = '50%';
     var dy = '${0.1 * geometry.base_width_svg}';
 
-    Tuple2<double?, int> ls_fs = _calculate_letter_spacing_and_font_size_insertion(length);
-    double? letter_spacing = ls_fs.item1;
-    int font_size = ls_fs.item2;
+    (double?, int) ls_fs = _calculate_letter_spacing_and_font_size_insertion(length);
+    double? letter_spacing = ls_fs.$1;
+    int font_size = ls_fs.$2;
 
     Map<String, dynamic> style_map;
     if (letter_spacing != null) {
@@ -203,14 +202,14 @@ class DesignMainDNASequenceComponent extends UiComponent2<DesignMainDNASequenceP
     var start_offset = '50%';
     var dy = '${0.1 * geometry.base_height_svg}';
 
-    Tuple2<double?, int> ls_fs;
+    (double?, int) ls_fs;
     if (util.is_hairpin(prev_domain, next_domain)) {
       ls_fs = _calculate_letter_spacing_and_font_size_hairpin(length);
     } else {
       ls_fs = _calculate_letter_spacing_and_font_size_loopout(length);
     }
-    double? letter_spacing = ls_fs.item1;
-    int font_size = ls_fs.item2;
+    double? letter_spacing = ls_fs.$1;
+    int font_size = ls_fs.$2;
 
     Map<String, dynamic> style_map;
     if (letter_spacing != null) {
@@ -240,9 +239,9 @@ class DesignMainDNASequenceComponent extends UiComponent2<DesignMainDNASequenceP
     var start_offset = '50%';
     var dy = '${0.1 * geometry.base_height_svg}';
 
-    Tuple2<double, int> ls_fs = _calculate_letter_spacing_and_font_size_extension(ext);
-    double letter_spacing = ls_fs.item1;
-    int font_size = ls_fs.item2;
+    (double, int) ls_fs = _calculate_letter_spacing_and_font_size_extension(ext);
+    double letter_spacing = ls_fs.$1;
+    int font_size = ls_fs.$2;
 
     Map<String, dynamic> style_map = {'letterSpacing': '${letter_spacing}em', 'fontSize': '${font_size}px'};
 
@@ -258,19 +257,19 @@ class DesignMainDNASequenceComponent extends UiComponent2<DesignMainDNASequenceP
   }
 }
 
-Tuple2<double, int> _calculate_letter_spacing_and_font_size_loopout(int len) {
+(double, int) _calculate_letter_spacing_and_font_size_loopout(int len) {
   double letter_spacing = 0;
   int font_size = 12;
-  return Tuple2<double, int>(letter_spacing, font_size);
+  return (letter_spacing, font_size);
 }
 
-Tuple2<double, int> _calculate_letter_spacing_and_font_size_extension(Extension ext) {
+(double, int) _calculate_letter_spacing_and_font_size_extension(Extension ext) {
   double letter_spacing = 0;
   int font_size = 12;
-  return Tuple2<double, int>(letter_spacing, font_size);
+  return (letter_spacing, font_size);
 }
 
-Tuple2<double?, int> _calculate_letter_spacing_and_font_size_hairpin(int len) {
+(double?, int) _calculate_letter_spacing_and_font_size_hairpin(int len) {
   double? letter_spacing;
   int font_size = max(6, 12 - max(0, len - 6));
   if (browser.isChrome) {
@@ -298,10 +297,10 @@ Tuple2<double?, int> _calculate_letter_spacing_and_font_size_hairpin(int len) {
     }
     letter_spacing = null;
   }
-  return Tuple2<double?, int>(letter_spacing, font_size);
+  return (letter_spacing, font_size);
 }
 
-Tuple2<double?, int> _calculate_letter_spacing_and_font_size_insertion(int num_insertions) {
+(double?, int) _calculate_letter_spacing_and_font_size_insertion(int num_insertions) {
   // UGGG
   double? letter_spacing;
   int font_size = max(6, 12 - (num_insertions - 1));
@@ -330,7 +329,7 @@ Tuple2<double?, int> _calculate_letter_spacing_and_font_size_insertion(int num_i
     }
     letter_spacing = null;
   }
-  return Tuple2<double?, int>(letter_spacing, font_size);
+  return (letter_spacing, font_size);
 }
 
 // keep this around in case this is how we want to export to an SVG file and it doesn't do textLength well

--- a/lib/src/view/design_main_domain_name_mismatches.dart
+++ b/lib/src/view/design_main_domain_name_mismatches.dart
@@ -2,7 +2,6 @@ import 'dart:html';
 
 import 'package:over_react/over_react.dart';
 import 'package:built_collection/built_collection.dart';
-import 'package:tuple/tuple.dart';
 
 import '../state/domain_name_mismatch.dart';
 import '../state/design.dart';
@@ -44,11 +43,11 @@ class DesignMainDomainNameMismatchesComponent extends UiComponent2<DesignMainDom
       for (var domain_name_mismatch in domain_name_mismatches) {
         Domain forward_domain = domain_name_mismatch.forward_domain;
         Domain reverse_domain = domain_name_mismatch.reverse_domain;
-        Tuple2<int, int>? overlap = forward_domain.compute_overlap(reverse_domain);
+        (int, int)? overlap = forward_domain.compute_overlap(reverse_domain);
         if (overlap == null) throw AssertionError('overlap should not be null');
 
         // draw mismatch stars at midpoint of overlap of domains
-        int mid = (overlap.item1 + overlap.item2) ~/ 2;
+        int mid = (overlap.$1 + overlap.$2) ~/ 2;
         for (Domain domain in [forward_domain, reverse_domain]) {
           var helix = props.design.helices[domain.helix]!;
           var group = props.design.groups[helix.group]!;

--- a/lib/src/view/design_main_strand_dna_extension_end_moving.dart
+++ b/lib/src/view/design_main_strand_dna_extension_end_moving.dart
@@ -93,7 +93,7 @@ class ExtensionEndMovingComponent extends UiComponent2<ExtensionEndMovingProps> 
       ..forward = props.forward!;
     var display_angle = util.compute_extension_length_and_angle_from_point(
         pos, props.attached_end_svg!, props.ext!, props.ext!.adjacent_domain, props.geometry!);
-    var rotation_degrees = util.compute_end_rotation(display_angle.item2, props.forward!, props.is_5p!);
+    var rotation_degrees = util.compute_end_rotation(display_angle.$2, props.forward!, props.is_5p!);
     // https://stackoverflow.com/questions/15138801/rotate-rectangle-around-its-own-center-in-svg
     end_props = end_props..transform = "rotate($rotation_degrees)";
     return end_props();

--- a/lib/src/view/design_main_strand_insertion.dart
+++ b/lib/src/view/design_main_strand_insertion.dart
@@ -7,7 +7,6 @@ import 'package:platform_detect/platform_detect.dart';
 import 'package:scadnano/src/state/context_menu.dart';
 import 'package:scadnano/src/state/dialog.dart';
 import 'package:scadnano/src/state/geometry.dart';
-import 'package:tuple/tuple.dart';
 
 import '../state/selectable.dart';
 import '../state/helix.dart';
@@ -21,7 +20,7 @@ import 'design_main_strand_loopout.dart';
 
 part 'design_main_strand_insertion.over_react.g.dart';
 
-typedef Tuple2<Insertion, Domain> PairedInsertionFinder(Insertion insertion, Domain substrand);
+typedef (Insertion, Domain) PairedInsertionFinder(Insertion insertion, Domain substrand);
 
 UiFactory<DesignMainStrandInsertionProps> DesignMainStrandInsertion = _$DesignMainStrandInsertion;
 

--- a/lib/src/view/design_main_warning_star.dart
+++ b/lib/src/view/design_main_warning_star.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:over_react/over_react.dart';
 import 'package:scadnano/src/state/geometry.dart';
-import 'package:tuple/tuple.dart';
 
 part 'design_main_warning_star.over_react.g.dart';
 
@@ -18,8 +17,8 @@ mixin DesignMainWarningStarProps on UiProps {
 class DesignMainWarningStarComponent extends UiComponent2<DesignMainWarningStarProps> {
   @override
   render() {
-    List<double> xs = List<double>.from(_star_at_origin().item1);
-    List<double> ys = List<double>.from(_star_at_origin().item2);
+    List<double> xs = List<double>.from(_star_at_origin().$1);
+    List<double> ys = List<double>.from(_star_at_origin().$2);
 
     num rotate_degrees = 0;
     if (!props.forward) {
@@ -49,7 +48,7 @@ class DesignMainWarningStarComponent extends UiComponent2<DesignMainWarningStarP
       ..transform = 'rotate(${rotate_degrees} ${props.base_svg_pos.x} ${props.base_svg_pos.y})')();
   }
 
-  Tuple2<List<double>, List<double>> _star_at_origin() {
+  (List<double>, List<double>) _star_at_origin() {
     // assume bottom points of star are at origin
     List<double> xs = [];
     List<double> ys = [];
@@ -72,6 +71,6 @@ class DesignMainWarningStarComponent extends UiComponent2<DesignMainWarningStarP
       inner_angle += 2 * pi / num_points;
       outer_angle += 2 * pi / num_points;
     }
-    return Tuple2<List<double>, List<double>>(xs, ys);
+    return (xs, ys);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,23 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "45cfa8471b89fb6643fe9bf51bd7931a76b8f5ec2d65de4fb176dba8d4f22c77"
+      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
       url: "https://pub.dev"
     source: hosted
-    version: "73.0.0"
+    version: "76.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.2"
+    version: "0.3.3"
   analyzer:
     dependency: "direct main"
     description:
       name: analyzer
-      sha256: "4959fec185fe70cce007c57e9ab6983101dbe593d2bf8bbfb4453aaec0cf470a"
+      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.8.0"
+    version: "6.11.0"
   archive:
     dependency: transitive
     description:
@@ -370,10 +370,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.2-main.4"
+    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
@@ -702,14 +702,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.22"
-  tuple:
-    dependency: "direct main"
-    description:
-      name: tuple
-      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,6 @@ dependencies:
   over_react: ^5.3.0
   spreadsheet_decoder: ^2.2.0
   test: ^1.25.8
-  tuple: ^2.0.2
   xml: ^6.3.0
   watcher: ^1.1.0
 

--- a/test/base_pairs_test.dart
+++ b/test/base_pairs_test.dart
@@ -1,7 +1,5 @@
 import 'dart:convert';
 
-import 'package:tuple/tuple.dart';
-
 import 'package:scadnano/src/actions/actions.dart';
 import 'package:scadnano/src/json_serializable.dart';
 import 'package:scadnano/src/reducers/app_state_reducer.dart';
@@ -87,7 +85,7 @@ main() {
       var overlapping_domains_h0 = test_design.find_overlapping_domains_on_helix(0);
 
       expect(overlapping_domains_h0.length, 1);
-      expect(overlapping_domains_h0, contains(Tuple2<Domain, Domain>(d01f, d01r)));
+      expect(overlapping_domains_h0, contains((d01f, d01r)));
     });
     test('find_overlapping_domains', () {
       var d01f = design.strands[0].domains[0];
@@ -115,14 +113,14 @@ main() {
       expect(overlapping_domains_h0.length, 4);
       expect(overlapping_domains_h1.length, 3);
 
-      expect(overlapping_domains_h0, contains(Tuple2<Domain, Domain>(d01f, d01r)));
-      expect(overlapping_domains_h0, contains(Tuple2<Domain, Domain>(d02f, d02r)));
-      expect(overlapping_domains_h0, contains(Tuple2<Domain, Domain>(d03f, d02r)));
-      expect(overlapping_domains_h0, contains(Tuple2<Domain, Domain>(d05f, d04r)));
+      expect(overlapping_domains_h0, contains((d01f, d01r)));
+      expect(overlapping_domains_h0, contains((d02f, d02r)));
+      expect(overlapping_domains_h0, contains((d03f, d02r)));
+      expect(overlapping_domains_h0, contains((d05f, d04r)));
 
-      expect(overlapping_domains_h1, contains(Tuple2<Domain, Domain>(d11f, d11r)));
-      expect(overlapping_domains_h1, contains(Tuple2<Domain, Domain>(d11f, d12r)));
-      expect(overlapping_domains_h1, contains(Tuple2<Domain, Domain>(d12f, d12r)));
+      expect(overlapping_domains_h1, contains((d11f, d11r)));
+      expect(overlapping_domains_h1, contains((d11f, d12r)));
+      expect(overlapping_domains_h1, contains((d12f, d12r)));
     });
 
     test('design_base_pairs_mismatches', () {

--- a/test/helix_relax_rolls_test.dart
+++ b/test/helix_relax_rolls_test.dart
@@ -17,7 +17,6 @@ import 'package:test/test.dart';
 
 import 'package:scadnano/src/state/design.dart';
 import 'package:scadnano/src/actions/actions.dart' as actions;
-import 'package:tuple/tuple.dart';
 
 import 'package:scadnano/src/util.dart' as util;
 import 'package:scadnano/src/constants.dart' as constants;
@@ -628,10 +627,10 @@ main() {
     });
 
     test('minimum_strain_angle_0_10_20_relative_to_0', () {
-      var relative_angles = [
-        Tuple2<double, double>(0, 0),
-        Tuple2<double, double>(10, 0),
-        Tuple2<double, double>(20, 0),
+      List<(double, double)> relative_angles = [
+        (0, 0),
+        (10, 0),
+        (20, 0),
       ];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 350.0;
@@ -639,10 +638,10 @@ main() {
     });
 
     test('minimum_strain_angle_0_10_50_relative_to_0', () {
-      var relative_angles = [
-        Tuple2<double, double>(0, 0),
-        Tuple2<double, double>(10, 0),
-        Tuple2<double, double>(50, 0),
+      List<(double, double)> relative_angles = [
+        (0, 0),
+        (10, 0),
+        (50, 0),
       ];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 340.0;
@@ -650,10 +649,10 @@ main() {
     });
 
     test('minimum_strain_angle_0_10_80_relative_to_0', () {
-      var relative_angles = [
-        Tuple2<double, double>(0, 0),
-        Tuple2<double, double>(10, 0),
-        Tuple2<double, double>(80, 0),
+      List<(double, double)> relative_angles = [
+        (0, 0),
+        (10, 0),
+        (80, 0),
       ];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 330.0;
@@ -661,10 +660,10 @@ main() {
     });
 
     test('minimum_strain_angle_350_0_10_relative_to_0', () {
-      var relative_angles = [
-        Tuple2<double, double>(350, 0),
-        Tuple2<double, double>(0, 0),
-        Tuple2<double, double>(10, 0),
+      List<(double, double)> relative_angles = [
+        (350, 0),
+        (0, 0),
+        (10, 0),
       ];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 0.0;
@@ -672,10 +671,10 @@ main() {
     });
 
     test('minimum_strain_angle_350_0_40_relative_to_0', () {
-      var relative_angles = [
-        Tuple2<double, double>(350, 0),
-        Tuple2<double, double>(0, 0),
-        Tuple2<double, double>(40, 0),
+      List<(double, double)> relative_angles = [
+        (350, 0),
+        (0, 0),
+        (40, 0),
       ];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 350.0;
@@ -683,10 +682,10 @@ main() {
     });
 
     test('minimum_strain_angle_350_10_60_relative_to_0', () {
-      var relative_angles = [
-        Tuple2<double, double>(350, 0),
-        Tuple2<double, double>(10, 0),
-        Tuple2<double, double>(60, 0),
+      List<(double, double)> relative_angles = [
+        (350, 0),
+        (10, 0),
+        (60, 0),
       ];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 340.0;
@@ -694,14 +693,14 @@ main() {
     });
 
     test('minimum_strain_angle_350_10_60_relative_to_0_and_20_0_310_relative_to_10', () {
-      var relative_angles = [
-        Tuple2<double, double>(350, 0), // -10
-        Tuple2<double, double>(10, 0), // 10
-        Tuple2<double, double>(60, 0), // 60
+      List<(double, double)> relative_angles = [
+        (350, 0), // -10
+        (10, 0), // 10
+        (60, 0), // 60
         ///////////////////////////////// ave to 20
-        Tuple2<double, double>(20, 10), // 10
-        Tuple2<double, double>(0, 10), // -10
-        Tuple2<double, double>(340, 10), // -30
+        (20, 10), // 10
+        (0, 10), // -10
+        (340, 10), // -30
         ///////////////////////////////// ave to -10
         ///////////////////////////////// total average is (20-10)/2 = 5, so 355 (-5) to correct it
       ];
@@ -711,9 +710,9 @@ main() {
     });
 
     test('minimum_strain_angle_179_181_relative_to_0', () {
-      var relative_angles = [
-        Tuple2<double, double>(179, 0),
-        Tuple2<double, double>(181, 0),
+      List<(double, double)> relative_angles = [
+        (179, 0),
+        (181, 0),
       ];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 180.0;
@@ -721,9 +720,9 @@ main() {
     });
 
     test('minimum_strain_angle_181_183_relative_to_0', () {
-      var relative_angles = [
-        Tuple2<double, double>(181, 0),
-        Tuple2<double, double>(183, 0),
+      List<(double, double)> relative_angles = [
+        (181, 0),
+        (183, 0),
       ];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 178.0;
@@ -731,10 +730,10 @@ main() {
     });
 
     test('minimum_strain_angle_174_179_184_relative_to_0', () {
-      var relative_angles = [
-        Tuple2<double, double>(174, 0),
-        Tuple2<double, double>(179, 0),
-        Tuple2<double, double>(184, 0),
+      List<(double, double)> relative_angles = [
+        (174, 0),
+        (179, 0),
+        (184, 0),
       ];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 181.0;

--- a/test/oxdna_export_test.dart
+++ b/test/oxdna_export_test.dart
@@ -4,7 +4,6 @@ import 'package:scadnano/src/state/grid_position.dart';
 import 'package:scadnano/src/state/group.dart';
 import 'package:scadnano/src/state/position3d.dart';
 import 'package:test/test.dart';
-import 'package:tuple/tuple.dart';
 
 import 'package:scadnano/src/middleware/oxdna_export.dart';
 import 'package:scadnano/src/state/helix.dart';
@@ -59,9 +58,9 @@ main() {
       int expected_num_nucleotides = 7 * 4;
       int expected_strand_length = 7 * 2;
 
-      Tuple2<String, String> oxdna_dat_top = to_oxdna_format(design);
-      List<String> dat_lines = oxdna_dat_top.item1.trim().split('\n');
-      List<String> top_lines = oxdna_dat_top.item2.trim().split('\n');
+      (String, String) oxdna_dat_top = to_oxdna_format(design);
+      List<String> dat_lines = oxdna_dat_top.$1.trim().split('\n');
+      List<String> top_lines = oxdna_dat_top.$2.trim().split('\n');
 
       // check length of output files are as expected (matches # of nucleotides plus header size)
       expect(dat_lines.length, expected_num_nucleotides + 3);
@@ -213,9 +212,9 @@ main() {
       int expected_num_nucleotides = 7 * 4;
       int expected_strand_length = 7 * 2;
 
-      Tuple2<String, String> oxdna_dat_top = to_oxdna_format(design);
-      List<String> dat_lines = oxdna_dat_top.item1.trim().split('\n');
-      List<String> top_lines = oxdna_dat_top.item2.trim().split('\n');
+      (String, String) oxdna_dat_top = to_oxdna_format(design);
+      List<String> dat_lines = oxdna_dat_top.$1.trim().split('\n');
+      List<String> top_lines = oxdna_dat_top.$2.trim().split('\n');
 
       // check length of output files are as expected (matches # of nucleotides plus header size)
       expect(dat_lines.length, expected_num_nucleotides + 3);
@@ -362,9 +361,9 @@ main() {
       int expected_num_nucleotides = 8 * 3;
       int expected_strand_length = 8 * 3;
 
-      Tuple2<String, String> oxdna_dat_top = to_oxdna_format(design);
-      List<String> dat_lines = oxdna_dat_top.item1.trim().split('\n');
-      List<String> top_lines = oxdna_dat_top.item2.trim().split('\n');
+      (String, String) oxdna_dat_top = to_oxdna_format(design);
+      List<String> dat_lines = oxdna_dat_top.$1.trim().split('\n');
+      List<String> top_lines = oxdna_dat_top.$2.trim().split('\n');
 
       // check length of output files are as expected (matches # of nucleotides plus header size)
       expect(dat_lines.length, expected_num_nucleotides + 3);
@@ -467,9 +466,9 @@ main() {
       int expected_num_nucleotides = 6;
       int expected_strand_length = 6;
 
-      Tuple2<String, String> oxdna_dat_top = to_oxdna_format(design);
-      List<String> dat_lines = oxdna_dat_top.item1.trim().split('\n');
-      List<String> top_lines = oxdna_dat_top.item2.trim().split('\n');
+      (String, String) oxdna_dat_top = to_oxdna_format(design);
+      List<String> dat_lines = oxdna_dat_top.$1.trim().split('\n');
+      List<String> top_lines = oxdna_dat_top.$2.trim().split('\n');
 
       // check length of output files are as expected (matches # of nucleotides plus header size)
       expect(dat_lines.length, expected_num_nucleotides + 3);
@@ -570,9 +569,9 @@ main() {
       int expected_num_nucleotides = 8;
       int expected_strand_length = 8;
 
-      Tuple2<String, String> oxdna_dat_top = to_oxdna_format(design);
-      List<String> dat_lines = oxdna_dat_top.item1.trim().split('\n');
-      List<String> top_lines = oxdna_dat_top.item2.trim().split('\n');
+      (String, String) oxdna_dat_top = to_oxdna_format(design);
+      List<String> dat_lines = oxdna_dat_top.$1.trim().split('\n');
+      List<String> top_lines = oxdna_dat_top.$2.trim().split('\n');
 
       // check length of output files are as expected (matches # of nucleotides plus header size)
       expect(dat_lines.length, expected_num_nucleotides + 3);
@@ -676,9 +675,9 @@ main() {
       int expected_strand_1_length = 7 + 4;
       int expected_strand_2_length = 7;
 
-      Tuple2<String, String> oxdna_dat_top = to_oxdna_format(design);
-      List<String> dat_lines = oxdna_dat_top.item1.trim().split('\n');
-      List<String> top_lines = oxdna_dat_top.item2.trim().split('\n');
+      (String, String) oxdna_dat_top = to_oxdna_format(design);
+      List<String> dat_lines = oxdna_dat_top.$1.trim().split('\n');
+      List<String> top_lines = oxdna_dat_top.$2.trim().split('\n');
 
       // check length of output files are as expected (matches # of nucleotides plus header size)
       expect(dat_lines.length, expected_num_nucleotides + 3);


### PR DESCRIPTION
## Description
This replaces all instances of `TupleX` with Dart's records.

## Related Issue
This fixes #984.

## Motivation and Context
This is much cleaner than using the `Tuple` library, and it was requested by #984.

## How Has This Been Tested?
This was tested using the already existing unit tests. Although, some of the unit tests were modified to accommodate this change.

## Screenshots (if appropriate):
N/A