### PR TITLE
Fixes #1023 - Update GitHub Actions Dart Version

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -13,10 +13,8 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v4
 
-      - name: Setup Dart SDK
+      - name: Setup Dart SDK  # This will use the latest version of dart unless specified otherwise.
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
-        with:
-          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+        with:
+          sdk: 3.7.3
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
         with:
-          sdk: 3.7.3
+          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -8,26 +8,19 @@ jobs:
   run_unit_tests:
     if: github.event.pull_request.draft == false
 
-    runs-on: ubuntu-22.04
-
+    runs-on: ubuntu-22.04  # Could use ubuntu-latest
     steps:
-      - name: Setup Dart SDK Step 1
-        run: sudo apt-get update
-      - name: Setup Dart SDK Step 2
-        run: sudo apt-get install apt-transport-https
-      - name: Setup Dart SDK Step 3
-        run: sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-      - name: Setup Dart SDK Step 4
-        run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-      - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.4/linux_packages/dart_3.5.4-1_amd64.deb
-      - name: Setup Dart SDK Step 6
-        run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
-      - uses: actions/checkout@v4
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+
       - name: Install dependencies
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub get
-      - name: Run tests
-        run: PATH="$PATH:/usr/lib/dart/bin" dart run build_runner test
+        run: dart pub get
+
+      - name: Run Tests
+        run: dart run build_runner test
 
   fail_if_pull_request_is_draft:
     if: github.event.pull_request.draft == true

--- a/.github/workflows/dart_formatting.yml
+++ b/.github/workflows/dart_formatting.yml
@@ -13,10 +13,8 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v4
 
-      - name: Setup Dart SDK
+      - name: Setup Dart SDK  # This will use the latest version of dart unless specified otherwise.
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
-        with:
-          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart_formatting.yml
+++ b/.github/workflows/dart_formatting.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+        with:
+          sdk: 3.7.3
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart_formatting.yml
+++ b/.github/workflows/dart_formatting.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
         with:
-          sdk: 3.7.3
+          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart_formatting.yml
+++ b/.github/workflows/dart_formatting.yml
@@ -8,26 +8,19 @@ jobs:
   check_formatting:
     if: github.event.pull_request.draft == false
 
-    runs-on: ubuntu-22.04
-
+    runs-on: ubuntu-22.04  # Could use ubuntu-latest
     steps:
-      - name: Setup Dart SDK Step 1
-        run: sudo apt-get update
-      - name: Setup Dart SDK Step 2
-        run: sudo apt-get install apt-transport-https
-      - name: Setup Dart SDK Step 3
-        run: sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-      - name: Setup Dart SDK Step 4
-        run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-      - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.4/linux_packages/dart_3.5.4-1_amd64.deb
-      - name: Setup Dart SDK Step 6
-        run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
-      - uses: actions/checkout@v4
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+
       - name: Install dependencies
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub get
+        run: dart pub get
+
       - name: Verify formatting
-        run: PATH="$PATH:/usr/lib/dart/bin" dart format -l 110 --output=none --set-exit-if-changed .
+        run: dart format -l 110 --output=none --set-exit-if-changed .
 
   fail_if_pull_request_is_draft:
     if: github.event.pull_request.draft == true

--- a/.github/workflows/gh-pages-dev.yml
+++ b/.github/workflows/gh-pages-dev.yml
@@ -20,10 +20,8 @@ jobs:
           ref: gh-pages
           path: gh-pages-repo
 
-      - name: Setup Dart SDK
+      - name: Setup Dart SDK  # This will use the latest version of dart unless specified otherwise.
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
-        with:
-          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/gh-pages-dev.yml
+++ b/.github/workflows/gh-pages-dev.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
         with:
-          sdk: 3.7.3
+          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/gh-pages-dev.yml
+++ b/.github/workflows/gh-pages-dev.yml
@@ -10,41 +10,27 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout dev branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: dev
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
           path: gh-pages-repo
 
-
-
-      - name: Setup Dart SDK Step 1
-        run: sudo apt-get update
-      - name: Setup Dart SDK Step 2
-        run: sudo apt-get install apt-transport-https
-      - name: Setup Dart SDK Step 3
-        run: sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-      - name: Setup Dart SDK Step 4
-        run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-      - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.4/linux_packages/dart_3.5.4-1_amd64.deb
-      - name: Setup Dart SDK Step 6
-        run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
 
       - name: Install dependencies
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub get
+        run: dart pub get
 
       - name: Install webdev
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub global activate webdev
-
+        run: dart pub global activate webdev
 
       - name: Build into gh-pages repo
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub global run webdev build -o web:gh-pages-repo/dev
-
+        run: dart pub global run webdev build -o web:gh-pages-repo/dev
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/gh-pages-dev.yml
+++ b/.github/workflows/gh-pages-dev.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+        with:
+          sdk: 3.7.3
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,10 +19,8 @@ jobs:
           ref: gh-pages
           path: gh-pages-repo
 
-      - name: Setup Dart SDK
+      - name: Setup Dart SDK  # This will use the latest version of dart unless specified otherwise.
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
-        with:
-          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+        with:
+          sdk: 3.7.3
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,45 +8,36 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-22.04
+
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
           path: gh-pages-repo
 
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
 
-
-      - name: Setup Dart SDK Step 1
-        run: sudo apt-get update
-      - name: Setup Dart SDK Step 2
-        run: sudo apt-get install apt-transport-https
-      - name: Setup Dart SDK Step 3
-        run: sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-      - name: Setup Dart SDK Step 4
-        run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-      - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.4/linux_packages/dart_3.5.4-1_amd64.deb
-      - name: Setup Dart SDK Step 6
-        run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
       - name: Install dependencies
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub get
+        run: dart pub get
 
-      - name: Install webdev
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub global activate webdev
-
+      - name: Activate webdev
+        run: dart pub global activate webdev
 
       - name: Build into gh-pages repo
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub global run webdev build -o web:/tmp/scadnano ; cp -r /tmp/scadnano/* gh-pages-repo
+        run: dart pub global run webdev build -o web:/tmp/scadnano ; cp -r /tmp/scadnano/* gh-pages-repo
+
       - name: Retrieve version
-        run: echo "VERSION=$(cat lib/src/constants.dart | grep  'const String CURRENT_VERSION = .*' | grep -oP '\d+\.\d+\.\d+')"  >> $GITHUB_ENV
+        run: echo "VERSION=$(cat lib/src/constants.dart | grep 'const String CURRENT_VERSION = .*' | grep -oP '\d+\.\d+\.\d+')" >> $GITHUB_ENV
+
       - name: Build into gh-pages-repo/VERSION
         run: |
           if [ "$VERSION" != "" ]; then
-             PATH="$PATH:/usr/lib/dart/bin" dart pub global run webdev build -o web:gh-pages-repo/v$VERSION
+             dart pub global run webdev build -o web:gh-pages-repo/v$VERSION
           else
              echo "::warning deploying VERSION skipped because VERSION number could not be found"
           fi

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
         with:
-          sdk: 3.7.3
+          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,23 +241,23 @@ git checkout dev
 
 ### Installing Dart
 
-This project requires using Dart version **3.5.4**, not the latest version. Click on a dropdown below for installation instructions for your operating system.
+This project requires using Dart version **3.7.3**, not the latest version. Click on a dropdown below for installation instructions for your operating system.
 
 <!--TODO: Find a way to use code blocks with syntax highlighting inside <details>-->
 
 <details><summary><strong>Windows</strong></summary>
 First, install <a href="https://chocolatey.org/install">Chocolatey</a> if you haven't already. If <code>choco help</code> shows a help menu for using Chocolatey, then you've set it up correctly.
 
-Then, open a shell (cmd/Powershell) with Administrative privileges (go to Start type `cmd`, right-click on "Command Prompt", or type Powershell and right-click on "Powershell"; in both cases pick "Run as administrator") and install Dart 3.5.4:
+Then, open a shell (cmd/Powershell) with Administrative privileges (go to Start type `cmd`, right-click on "Command Prompt", or type Powershell and right-click on "Powershell"; in both cases pick "Run as administrator") and install Dart 3.7.3:
 
 <pre>
-choco install dart-sdk --version 3.5.4
+choco install dart-sdk --version 3.7.3
 </pre>
 
 To stop Chocolatey from automatically updating Dart to the latest version, pin it:
 
 <pre>
-choco pin --name="'dart-sdk'" --version="'3.5.4'"
+choco pin --name="'dart-sdk'" --version="'3.7.3'"
 </pre>
 
 </details>
@@ -267,16 +267,16 @@ First, install <a href="https://brew.sh/">Homebrew</a> if you haven't already. I
 
 It may help to run `brew tap dart-lang/dart` first.
 
-Then, install Dart 3.5.4:
+Then, install Dart 3.7.3:
 
 <pre>
-brew install dart@3.5.4
+brew install dart@3.7.3
 </pre>
 
 To stop Homebrew from automatically updating Dart to the latest version, pin it:
 
 <pre>
-brew pin dart@3.5.4
+brew pin dart@3.7.3
 </pre>
 
 If running `dart` in a terminal now does not work, you may need to follow <a href="https://docs.brew.sh/FAQ#my-mac-apps-dont-find-homebrew-utilities">these instructions</a>.
@@ -292,17 +292,17 @@ wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dea
 echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
 </pre>
 
-Then, install Dart 3.5.4:
+Then, install Dart 3.7.3:
 
 <pre>
 sudo apt-get update
-sudo apt-get install dart=3.5.4
+sudo apt-get install dart=3.7.3
 </pre>
 
 To stop apt from automatically updating Dart to the latest version, hold it:
 
 <pre>
-sudo apt-mark hold dart=3.5.4
+sudo apt-mark hold dart=3.7.3
 </pre>
 
 </details>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,23 +241,17 @@ git checkout dev
 
 ### Installing Dart
 
-This project requires using Dart version **3.7.3**, not the latest version. Click on a dropdown below for installation instructions for your operating system.
+This project requires using the latest Dart version. Click on a dropdown below for installation instructions for your operating system.
 
 <!--TODO: Find a way to use code blocks with syntax highlighting inside <details>-->
 
 <details><summary><strong>Windows</strong></summary>
 First, install <a href="https://chocolatey.org/install">Chocolatey</a> if you haven't already. If <code>choco help</code> shows a help menu for using Chocolatey, then you've set it up correctly.
 
-Then, open a shell (cmd/Powershell) with Administrative privileges (go to Start type `cmd`, right-click on "Command Prompt", or type Powershell and right-click on "Powershell"; in both cases pick "Run as administrator") and install Dart 3.7.3:
+Then, open a shell (cmd/Powershell) with Administrative privileges (go to Start type `cmd`, right-click on "Command Prompt", or type Powershell and right-click on "Powershell"; in both cases pick "Run as administrator") and install Dart:
 
 <pre>
-choco install dart-sdk --version 3.7.3
-</pre>
-
-To stop Chocolatey from automatically updating Dart to the latest version, pin it:
-
-<pre>
-choco pin --name="'dart-sdk'" --version="'3.7.3'"
+choco install dart-sdk
 </pre>
 
 </details>
@@ -267,16 +261,10 @@ First, install <a href="https://brew.sh/">Homebrew</a> if you haven't already. I
 
 It may help to run `brew tap dart-lang/dart` first.
 
-Then, install Dart 3.7.3:
+Then, install Dart:
 
 <pre>
-brew install dart@3.7.3
-</pre>
-
-To stop Homebrew from automatically updating Dart to the latest version, pin it:
-
-<pre>
-brew pin dart@3.7.3
+brew install dart
 </pre>
 
 If running `dart` in a terminal now does not work, you may need to follow <a href="https://docs.brew.sh/FAQ#my-mac-apps-dont-find-homebrew-utilities">these instructions</a>.
@@ -292,17 +280,11 @@ wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dea
 echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
 </pre>
 
-Then, install Dart 3.7.3:
+Then, install Dart:
 
 <pre>
 sudo apt-get update
-sudo apt-get install dart=3.7.3
-</pre>
-
-To stop apt from automatically updating Dart to the latest version, hold it:
-
-<pre>
-sudo apt-mark hold dart=3.7.3
+sudo apt-get install dart
 </pre>
 
 </details>


### PR DESCRIPTION
## Description
This updates the dart version in the GitHub actions file(s) to the version specified by `pubspec.yaml`.

## Related Issue
This fixes #1023.

## Motivation and Context
The actions were failing in the dev branch because of a mismatch between the Dart versions and the `pubspec.yaml` versions. The issue is specified at #1023.

## How Has This Been Tested?
I was researching possible solutions to make updating to the latest dart version easier, and came across [this](https://github.com/dart-lang/setup-dart). It's a GitHub action created by the Dart team to automatically download and install the latest (or a specific) version of Dart.

As for testing, you can view the actions below to see that they both work and pass. **However** there is a big caveat. I have also updated the `.github/workflows/gh-pages.yml` and `.github/workflows/gh-pages-dev.yml` with this. I am *unsure* if those work as intended. Further testing **will need** to be done before merging as I do not want to mess up the actual scadnano website.