### PR TITLE
Fixes #1025  - Add Dependabot Support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pub"
+    directory: "/" # Directory of pubspec.yaml
+    target-branch: "dev"
+    schedule:
+      interval: "weekly" # daily, weekly, monthly

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -13,10 +13,8 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v4
 
-      - name: Setup Dart SDK
+      - name: Setup Dart SDK  # This will use the latest version of dart unless specified otherwise.
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
-        with:
-          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+        with:
+          sdk: 3.7.3
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
         with:
-          sdk: 3.7.3
+          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -8,26 +8,19 @@ jobs:
   run_unit_tests:
     if: github.event.pull_request.draft == false
 
-    runs-on: ubuntu-22.04
-
+    runs-on: ubuntu-22.04  # Could use ubuntu-latest
     steps:
-      - name: Setup Dart SDK Step 1
-        run: sudo apt-get update
-      - name: Setup Dart SDK Step 2
-        run: sudo apt-get install apt-transport-https
-      - name: Setup Dart SDK Step 3
-        run: sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-      - name: Setup Dart SDK Step 4
-        run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-      - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.4/linux_packages/dart_3.5.4-1_amd64.deb
-      - name: Setup Dart SDK Step 6
-        run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
-      - uses: actions/checkout@v4
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+
       - name: Install dependencies
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub get
-      - name: Run tests
-        run: PATH="$PATH:/usr/lib/dart/bin" dart run build_runner test
+        run: dart pub get
+
+      - name: Run Tests
+        run: dart run build_runner test
 
   fail_if_pull_request_is_draft:
     if: github.event.pull_request.draft == true

--- a/.github/workflows/dart_formatting.yml
+++ b/.github/workflows/dart_formatting.yml
@@ -13,10 +13,8 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v4
 
-      - name: Setup Dart SDK
+      - name: Setup Dart SDK  # This will use the latest version of dart unless specified otherwise.
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
-        with:
-          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart_formatting.yml
+++ b/.github/workflows/dart_formatting.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+        with:
+          sdk: 3.7.3
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart_formatting.yml
+++ b/.github/workflows/dart_formatting.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
         with:
-          sdk: 3.7.3
+          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart_formatting.yml
+++ b/.github/workflows/dart_formatting.yml
@@ -8,26 +8,19 @@ jobs:
   check_formatting:
     if: github.event.pull_request.draft == false
 
-    runs-on: ubuntu-22.04
-
+    runs-on: ubuntu-22.04  # Could use ubuntu-latest
     steps:
-      - name: Setup Dart SDK Step 1
-        run: sudo apt-get update
-      - name: Setup Dart SDK Step 2
-        run: sudo apt-get install apt-transport-https
-      - name: Setup Dart SDK Step 3
-        run: sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-      - name: Setup Dart SDK Step 4
-        run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-      - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.4/linux_packages/dart_3.5.4-1_amd64.deb
-      - name: Setup Dart SDK Step 6
-        run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
-      - uses: actions/checkout@v4
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+
       - name: Install dependencies
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub get
+        run: dart pub get
+
       - name: Verify formatting
-        run: PATH="$PATH:/usr/lib/dart/bin" dart format -l 110 --output=none --set-exit-if-changed .
+        run: dart format -l 110 --output=none --set-exit-if-changed .
 
   fail_if_pull_request_is_draft:
     if: github.event.pull_request.draft == true

--- a/.github/workflows/gh-pages-dev.yml
+++ b/.github/workflows/gh-pages-dev.yml
@@ -20,10 +20,8 @@ jobs:
           ref: gh-pages
           path: gh-pages-repo
 
-      - name: Setup Dart SDK
+      - name: Setup Dart SDK  # This will use the latest version of dart unless specified otherwise.
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
-        with:
-          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/gh-pages-dev.yml
+++ b/.github/workflows/gh-pages-dev.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
         with:
-          sdk: 3.7.3
+          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/gh-pages-dev.yml
+++ b/.github/workflows/gh-pages-dev.yml
@@ -10,41 +10,27 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout dev branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: dev
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
           path: gh-pages-repo
 
-
-
-      - name: Setup Dart SDK Step 1
-        run: sudo apt-get update
-      - name: Setup Dart SDK Step 2
-        run: sudo apt-get install apt-transport-https
-      - name: Setup Dart SDK Step 3
-        run: sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-      - name: Setup Dart SDK Step 4
-        run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-      - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.4/linux_packages/dart_3.5.4-1_amd64.deb
-      - name: Setup Dart SDK Step 6
-        run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
 
       - name: Install dependencies
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub get
+        run: dart pub get
 
       - name: Install webdev
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub global activate webdev
-
+        run: dart pub global activate webdev
 
       - name: Build into gh-pages repo
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub global run webdev build -o web:gh-pages-repo/dev
-
+        run: dart pub global run webdev build -o web:gh-pages-repo/dev
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/gh-pages-dev.yml
+++ b/.github/workflows/gh-pages-dev.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+        with:
+          sdk: 3.7.3
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,10 +19,8 @@ jobs:
           ref: gh-pages
           path: gh-pages-repo
 
-      - name: Setup Dart SDK
+      - name: Setup Dart SDK  # This will use the latest version of dart unless specified otherwise.
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
-        with:
-          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+        with:
+          sdk: 3.7.3
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,45 +8,36 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-22.04
+
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
           path: gh-pages-repo
 
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
 
-
-      - name: Setup Dart SDK Step 1
-        run: sudo apt-get update
-      - name: Setup Dart SDK Step 2
-        run: sudo apt-get install apt-transport-https
-      - name: Setup Dart SDK Step 3
-        run: sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-      - name: Setup Dart SDK Step 4
-        run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-      - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.4/linux_packages/dart_3.5.4-1_amd64.deb
-      - name: Setup Dart SDK Step 6
-        run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
       - name: Install dependencies
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub get
+        run: dart pub get
 
-      - name: Install webdev
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub global activate webdev
-
+      - name: Activate webdev
+        run: dart pub global activate webdev
 
       - name: Build into gh-pages repo
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub global run webdev build -o web:/tmp/scadnano ; cp -r /tmp/scadnano/* gh-pages-repo
+        run: dart pub global run webdev build -o web:/tmp/scadnano ; cp -r /tmp/scadnano/* gh-pages-repo
+
       - name: Retrieve version
-        run: echo "VERSION=$(cat lib/src/constants.dart | grep  'const String CURRENT_VERSION = .*' | grep -oP '\d+\.\d+\.\d+')"  >> $GITHUB_ENV
+        run: echo "VERSION=$(cat lib/src/constants.dart | grep 'const String CURRENT_VERSION = .*' | grep -oP '\d+\.\d+\.\d+')" >> $GITHUB_ENV
+
       - name: Build into gh-pages-repo/VERSION
         run: |
           if [ "$VERSION" != "" ]; then
-             PATH="$PATH:/usr/lib/dart/bin" dart pub global run webdev build -o web:gh-pages-repo/v$VERSION
+             dart pub global run webdev build -o web:gh-pages-repo/v$VERSION
           else
              echo "::warning deploying VERSION skipped because VERSION number could not be found"
           fi

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
         with:
-          sdk: 3.7.3
+          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,23 +241,23 @@ git checkout dev
 
 ### Installing Dart
 
-This project requires using Dart version **3.5.4**, not the latest version. Click on a dropdown below for installation instructions for your operating system.
+This project requires using Dart version **3.7.3**, not the latest version. Click on a dropdown below for installation instructions for your operating system.
 
 <!--TODO: Find a way to use code blocks with syntax highlighting inside <details>-->
 
 <details><summary><strong>Windows</strong></summary>
 First, install <a href="https://chocolatey.org/install">Chocolatey</a> if you haven't already. If <code>choco help</code> shows a help menu for using Chocolatey, then you've set it up correctly.
 
-Then, open a shell (cmd/Powershell) with Administrative privileges (go to Start type `cmd`, right-click on "Command Prompt", or type Powershell and right-click on "Powershell"; in both cases pick "Run as administrator") and install Dart 3.5.4:
+Then, open a shell (cmd/Powershell) with Administrative privileges (go to Start type `cmd`, right-click on "Command Prompt", or type Powershell and right-click on "Powershell"; in both cases pick "Run as administrator") and install Dart 3.7.3:
 
 <pre>
-choco install dart-sdk --version 3.5.4
+choco install dart-sdk --version 3.7.3
 </pre>
 
 To stop Chocolatey from automatically updating Dart to the latest version, pin it:
 
 <pre>
-choco pin --name="'dart-sdk'" --version="'3.5.4'"
+choco pin --name="'dart-sdk'" --version="'3.7.3'"
 </pre>
 
 </details>
@@ -267,16 +267,16 @@ First, install <a href="https://brew.sh/">Homebrew</a> if you haven't already. I
 
 It may help to run `brew tap dart-lang/dart` first.
 
-Then, install Dart 3.5.4:
+Then, install Dart 3.7.3:
 
 <pre>
-brew install dart@3.5.4
+brew install dart@3.7.3
 </pre>
 
 To stop Homebrew from automatically updating Dart to the latest version, pin it:
 
 <pre>
-brew pin dart@3.5.4
+brew pin dart@3.7.3
 </pre>
 
 If running `dart` in a terminal now does not work, you may need to follow <a href="https://docs.brew.sh/FAQ#my-mac-apps-dont-find-homebrew-utilities">these instructions</a>.
@@ -292,17 +292,17 @@ wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dea
 echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
 </pre>
 
-Then, install Dart 3.5.4:
+Then, install Dart 3.7.3:
 
 <pre>
 sudo apt-get update
-sudo apt-get install dart=3.5.4
+sudo apt-get install dart=3.7.3
 </pre>
 
 To stop apt from automatically updating Dart to the latest version, hold it:
 
 <pre>
-sudo apt-mark hold dart=3.5.4
+sudo apt-mark hold dart=3.7.3
 </pre>
 
 </details>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,23 +241,17 @@ git checkout dev
 
 ### Installing Dart
 
-This project requires using Dart version **3.7.3**, not the latest version. Click on a dropdown below for installation instructions for your operating system.
+This project requires using the latest Dart version. Click on a dropdown below for installation instructions for your operating system.
 
 <!--TODO: Find a way to use code blocks with syntax highlighting inside <details>-->
 
 <details><summary><strong>Windows</strong></summary>
 First, install <a href="https://chocolatey.org/install">Chocolatey</a> if you haven't already. If <code>choco help</code> shows a help menu for using Chocolatey, then you've set it up correctly.
 
-Then, open a shell (cmd/Powershell) with Administrative privileges (go to Start type `cmd`, right-click on "Command Prompt", or type Powershell and right-click on "Powershell"; in both cases pick "Run as administrator") and install Dart 3.7.3:
+Then, open a shell (cmd/Powershell) with Administrative privileges (go to Start type `cmd`, right-click on "Command Prompt", or type Powershell and right-click on "Powershell"; in both cases pick "Run as administrator") and install Dart:
 
 <pre>
-choco install dart-sdk --version 3.7.3
-</pre>
-
-To stop Chocolatey from automatically updating Dart to the latest version, pin it:
-
-<pre>
-choco pin --name="'dart-sdk'" --version="'3.7.3'"
+choco install dart-sdk
 </pre>
 
 </details>
@@ -267,16 +261,10 @@ First, install <a href="https://brew.sh/">Homebrew</a> if you haven't already. I
 
 It may help to run `brew tap dart-lang/dart` first.
 
-Then, install Dart 3.7.3:
+Then, install Dart:
 
 <pre>
-brew install dart@3.7.3
-</pre>
-
-To stop Homebrew from automatically updating Dart to the latest version, pin it:
-
-<pre>
-brew pin dart@3.7.3
+brew install dart
 </pre>
 
 If running `dart` in a terminal now does not work, you may need to follow <a href="https://docs.brew.sh/FAQ#my-mac-apps-dont-find-homebrew-utilities">these instructions</a>.
@@ -292,17 +280,11 @@ wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dea
 echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
 </pre>
 
-Then, install Dart 3.7.3:
+Then, install Dart:
 
 <pre>
 sudo apt-get update
-sudo apt-get install dart=3.7.3
-</pre>
-
-To stop apt from automatically updating Dart to the latest version, hold it:
-
-<pre>
-sudo apt-mark hold dart=3.7.3
+sudo apt-get install dart
 </pre>
 
 </details>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -34,26 +34,26 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   bazel_worker:
     dependency: transitive
     description:
       name: bazel_worker
-      sha256: "57035594b87d9f5af99f1a80e1edf5411dadbdf5acfc4f90403e3849f57dd0f0"
+      sha256: "373a6ef07caa6c674c1cf144a5fe1e0f712c040552031ce669f298e35f7e110a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   boolean_selector:
     dependency: transitive
     description:
@@ -66,74 +66,74 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
+      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "79b2aef6ac2ed00046867ed354c88778c9c0f029df8a20fe10b5436826721ef9"
+      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.0.4"
   build_modules:
     dependency: transitive
     description:
       name: build_modules
-      sha256: "349f492c6cf66d32d24b71368908df23426440bf9ee4642fdb79978adb82a877"
+      sha256: b1fc29a603669b25a5d95cc9610ed649e9f00e6075e5b6b721aa1a095cff13de
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.12"
+    version: "5.0.13"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "028819cfb90051c6b5440c7e574d1896f8037e3c96cf17aaeb054c9311cfbf4d"
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.13"
+    version: "2.4.15"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0
+      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.2"
+    version: "8.0.0"
   build_test:
     dependency: "direct dev"
     description:
       name: build_test
-      sha256: "260dbba934f41b0a42935e9cae1f5731b94f0c3e489dc97bcf8e281265aaa5ae"
+      sha256: a580c76c28440d0006b75c6746bbbb3c1648959ba9e1afae2c2b0f2c26acdf3d
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.3"
   build_web_compilers:
     dependency: "direct dev"
     description:
       name: build_web_compilers
-      sha256: cbe4deca108e5a9949df0065e7ef3777f54d8545b9232f2d8ef74601f2fb2df3
+      sha256: f9b8e84dbfa7688221c2376e6f68ffd796597785a0a5b1e8cd2516a92fdc0a3c
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.3"
+    version: "4.1.5"
   built_collection:
     dependency: "direct main"
     description:
@@ -146,18 +146,18 @@ packages:
     dependency: "direct main"
     description:
       name: built_value
-      sha256: "28a712df2576b63c6c005c465989a348604960c0958d28be5303ba9baa841ac2"
+      sha256: ea90e81dc4a25a043d9bee692d20ed6d1c4a1662a28c03a96417446c093ed6b4
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.3"
+    version: "8.9.5"
   built_value_generator:
     dependency: "direct dev"
     description:
       name: built_value_generator
-      sha256: bb06c5e9dbdbd35ed6de21520e2e5112582c964fa584e2a4bb59887fc7a169b0
+      sha256: be8640bd52d67a5e6747379778b81ca2e6a40f61df475f81beb72fde62e32524
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.2"
+    version: "8.9.5"
   checked_yaml:
     dependency: transitive
     description:
@@ -166,6 +166,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   clock:
     dependency: transitive
     description:
@@ -210,10 +218,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: e3493833ea012784c740e341952298f1cc77f1f01b1bbc3eb4eecf6984fb7f43
+      sha256: "802bd084fb82e55df091ec8ad1553a7331b61c08251eef19a508b6f3f3a9858d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.13.1"
   crypto:
     dependency: transitive
     description:
@@ -234,10 +242,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "7856d364b589d1f08986e140938578ed36ed948581fbc3bc9aef1805039ac5ab"
+      sha256: "7306ab8a2359a48d22310ad823521d723acfed60ee1f7e37388e8986853b6820"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.7"
+    version: "2.3.8"
   dialog:
     dependency: "direct main"
     description:
@@ -282,10 +290,10 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   graphs:
     dependency: transitive
     description:
@@ -298,18 +306,18 @@ packages:
     dependency: transitive
     description:
       name: html
-      sha256: "1fc58edeaec4307368c60d59b7e15b9d658b57d7f3125098b6294153c75337ec"
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
       url: "https://pub.dev"
     source: hosted
-    version: "0.15.5"
+    version: "0.15.6"
   http:
     dependency: "direct main"
     description:
       name: http
-      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
+      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.4.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -394,10 +402,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -418,26 +426,26 @@ packages:
     dependency: "direct main"
     description:
       name: over_react
-      sha256: "9052c0c979811bd7ff35a145bd79de0da6f6f107017909826ed24fc9ee83b990"
+      sha256: cc478423217914a7e412dc6d8a71df804341b5af2db8718e16e7f6cd39ed912d
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.1"
+    version: "5.4.4"
   over_react_test:
     dependency: "direct dev"
     description:
       name: over_react_test
-      sha256: "4b88ea0db06a2ad7d331cf2d1c68fdd531eee6273f3f61b47d4f16c973d6eb57"
+      sha256: "1469bf980b3e917ef2e64936d491fdf52e375710ed495918970446040da77e50"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      sha256: "92d4488434b520a62570293fbd33bb556c7d49230791c1b4bbd973baf6d2dc67"
+      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.0"
   path:
     dependency: "direct main"
     description:
@@ -450,10 +458,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
+      sha256: "07c8f0b1913bcde1ff0d26e57ace2f3012ccbf2b204e070290dad3bb22797646"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "6.1.0"
   platform_detect:
     dependency: "direct main"
     description:
@@ -474,26 +482,26 @@ packages:
     dependency: transitive
     description:
       name: protobuf
-      sha256: "68645b24e0716782e58948f8467fd42a880f255096a821f9e7d0ec625b00c84d"
+      sha256: fbb0c37d435641d0b84813c1dad41e6fa61ddc880a320bce16b3063ecec35aa6
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.2.0"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: "81876843eb50dc2e1e5b151792c9a985c5ed2536914115ed04e9c8528f6647b0"
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   quiver:
     dependency: "direct main"
     description:
@@ -506,10 +514,10 @@ packages:
     dependency: "direct main"
     description:
       name: react
-      sha256: cebcf69d0366f72552672a0a034a75277b67711b4f1c2c71cd1d8d134fadf8c5
+      sha256: "85f92902849961083e22fa17c5916da3ca9dbb84481c87cded301b8e96812eda"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "7.3.0"
   redux:
     dependency: "direct main"
     description:
@@ -570,18 +578,18 @@ packages:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   source_gen:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
+      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "2.0.0"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -626,10 +634,10 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "4ac0537115a24d772c408a2520ecd0abb99bca2ea9c4e634ccbdbfae64fe17ec"
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
@@ -658,34 +666,34 @@ packages:
     dependency: "direct main"
     description:
       name: test
-      sha256: "8391fbe68d520daf2314121764d38e37f934c02fd7301ad18307bd93bd6b725d"
+      sha256: f1665eeffe3b6b193548b5f515e8d1b54ccd9a6e0e7721a417e134e7ed7f06a1
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.14"
+    version: "1.26.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "6c7653816b1c938e121b69ff63a33c9dc68102b65a5fb0a5c0f9786256ed33e6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.5"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
+      sha256: "3caa7c3956b366643b2dedecff764cc32030317b2a15252aed845570df6bcc0f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.8"
+    version: "0.6.9"
   test_html_builder:
     dependency: "direct dev"
     description:
       name: test_html_builder
-      sha256: f5ff610bd16608eb046543e315b33cfe07ce339388b6e07258772e52a800d941
+      sha256: "0d7a60f43ca39ce73bb05505820d42026ed93fe476aeac2cc398ce30e00890ed"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.12"
   timing:
     dependency: transitive
     description:
@@ -754,26 +762,26 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   web_socket:
     dependency: transitive
     description:
       name: web_socket
-      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.6"
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "9f187088ed104edd8662ca07af4b124465893caf063ba29758f97af57e61da8f"
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.3"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -799,4 +807,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.0 <3.8.0-z"
+  dart: ">=3.7.0 <3.9.0-z"


### PR DESCRIPTION
## Description
This is a small change which adds dependabot support.

## Related Issue
This fixes #1025.

## Motivation and Context
Dependabot can help keep packages up-to-date. I noticed in the old PRs that some version of dependabot has existed before. Since this is a small change, please let me know if this is not necessary, it did not take much time to add!

There are some caveats, I believe if there is a major security vulnerability, it will bypass the `dev` branch, and make a direct PR for the `main` branch instead. Otherwise, under normal circumstances, it should make a PR for the `dev` branch only.
