### PR TITLE
Fixes #984 - Replace Tuples with Records

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -13,10 +13,8 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v4
 
-      - name: Setup Dart SDK
+      - name: Setup Dart SDK  # This will use the latest version of dart unless specified otherwise.
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
-        with:
-          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+        with:
+          sdk: 3.7.3
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
         with:
-          sdk: 3.7.3
+          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -8,26 +8,19 @@ jobs:
   run_unit_tests:
     if: github.event.pull_request.draft == false
 
-    runs-on: ubuntu-22.04
-
+    runs-on: ubuntu-22.04  # Could use ubuntu-latest
     steps:
-      - name: Setup Dart SDK Step 1
-        run: sudo apt-get update
-      - name: Setup Dart SDK Step 2
-        run: sudo apt-get install apt-transport-https
-      - name: Setup Dart SDK Step 3
-        run: sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-      - name: Setup Dart SDK Step 4
-        run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-      - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.4/linux_packages/dart_3.5.4-1_amd64.deb
-      - name: Setup Dart SDK Step 6
-        run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
-      - uses: actions/checkout@v4
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+
       - name: Install dependencies
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub get
-      - name: Run tests
-        run: PATH="$PATH:/usr/lib/dart/bin" dart run build_runner test
+        run: dart pub get
+
+      - name: Run Tests
+        run: dart run build_runner test
 
   fail_if_pull_request_is_draft:
     if: github.event.pull_request.draft == true

--- a/.github/workflows/dart_formatting.yml
+++ b/.github/workflows/dart_formatting.yml
@@ -13,10 +13,8 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v4
 
-      - name: Setup Dart SDK
+      - name: Setup Dart SDK  # This will use the latest version of dart unless specified otherwise.
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
-        with:
-          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart_formatting.yml
+++ b/.github/workflows/dart_formatting.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+        with:
+          sdk: 3.7.3
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart_formatting.yml
+++ b/.github/workflows/dart_formatting.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
         with:
-          sdk: 3.7.3
+          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart_formatting.yml
+++ b/.github/workflows/dart_formatting.yml
@@ -8,26 +8,19 @@ jobs:
   check_formatting:
     if: github.event.pull_request.draft == false
 
-    runs-on: ubuntu-22.04
-
+    runs-on: ubuntu-22.04  # Could use ubuntu-latest
     steps:
-      - name: Setup Dart SDK Step 1
-        run: sudo apt-get update
-      - name: Setup Dart SDK Step 2
-        run: sudo apt-get install apt-transport-https
-      - name: Setup Dart SDK Step 3
-        run: sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-      - name: Setup Dart SDK Step 4
-        run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-      - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.4/linux_packages/dart_3.5.4-1_amd64.deb
-      - name: Setup Dart SDK Step 6
-        run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
-      - uses: actions/checkout@v4
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+
       - name: Install dependencies
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub get
+        run: dart pub get
+
       - name: Verify formatting
-        run: PATH="$PATH:/usr/lib/dart/bin" dart format -l 110 --output=none --set-exit-if-changed .
+        run: dart format -l 110 --output=none --set-exit-if-changed .
 
   fail_if_pull_request_is_draft:
     if: github.event.pull_request.draft == true

--- a/.github/workflows/gh-pages-dev.yml
+++ b/.github/workflows/gh-pages-dev.yml
@@ -20,10 +20,8 @@ jobs:
           ref: gh-pages
           path: gh-pages-repo
 
-      - name: Setup Dart SDK
+      - name: Setup Dart SDK  # This will use the latest version of dart unless specified otherwise.
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
-        with:
-          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/gh-pages-dev.yml
+++ b/.github/workflows/gh-pages-dev.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
         with:
-          sdk: 3.7.3
+          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/gh-pages-dev.yml
+++ b/.github/workflows/gh-pages-dev.yml
@@ -10,41 +10,27 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout dev branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: dev
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
           path: gh-pages-repo
 
-
-
-      - name: Setup Dart SDK Step 1
-        run: sudo apt-get update
-      - name: Setup Dart SDK Step 2
-        run: sudo apt-get install apt-transport-https
-      - name: Setup Dart SDK Step 3
-        run: sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-      - name: Setup Dart SDK Step 4
-        run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-      - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.4/linux_packages/dart_3.5.4-1_amd64.deb
-      - name: Setup Dart SDK Step 6
-        run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
 
       - name: Install dependencies
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub get
+        run: dart pub get
 
       - name: Install webdev
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub global activate webdev
-
+        run: dart pub global activate webdev
 
       - name: Build into gh-pages repo
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub global run webdev build -o web:gh-pages-repo/dev
-
+        run: dart pub global run webdev build -o web:gh-pages-repo/dev
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/gh-pages-dev.yml
+++ b/.github/workflows/gh-pages-dev.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+        with:
+          sdk: 3.7.3
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,10 +19,8 @@ jobs:
           ref: gh-pages
           path: gh-pages-repo
 
-      - name: Setup Dart SDK
+      - name: Setup Dart SDK  # This will use the latest version of dart unless specified otherwise.
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
-        with:
-          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
+        with:
+          sdk: 3.7.3
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,45 +8,36 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-22.04
+
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
           path: gh-pages-repo
 
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
 
-
-      - name: Setup Dart SDK Step 1
-        run: sudo apt-get update
-      - name: Setup Dart SDK Step 2
-        run: sudo apt-get install apt-transport-https
-      - name: Setup Dart SDK Step 3
-        run: sudo sh -c 'wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-      - name: Setup Dart SDK Step 4
-        run: sudo sh -c 'wget -qO- https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-      - name: Setup Dart SDK Step 5
-        run: wget -O /tmp/dart_3.5.4-1_amd64.deb https://storage.googleapis.com/dart-archive/channels/stable/release/3.5.4/linux_packages/dart_3.5.4-1_amd64.deb
-      - name: Setup Dart SDK Step 6
-        run: sudo apt install /tmp/dart_3.5.4-1_amd64.deb
       - name: Install dependencies
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub get
+        run: dart pub get
 
-      - name: Install webdev
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub global activate webdev
-
+      - name: Activate webdev
+        run: dart pub global activate webdev
 
       - name: Build into gh-pages repo
-        run: PATH="$PATH:/usr/lib/dart/bin" dart pub global run webdev build -o web:/tmp/scadnano ; cp -r /tmp/scadnano/* gh-pages-repo
+        run: dart pub global run webdev build -o web:/tmp/scadnano ; cp -r /tmp/scadnano/* gh-pages-repo
+
       - name: Retrieve version
-        run: echo "VERSION=$(cat lib/src/constants.dart | grep  'const String CURRENT_VERSION = .*' | grep -oP '\d+\.\d+\.\d+')"  >> $GITHUB_ENV
+        run: echo "VERSION=$(cat lib/src/constants.dart | grep 'const String CURRENT_VERSION = .*' | grep -oP '\d+\.\d+\.\d+')" >> $GITHUB_ENV
+
       - name: Build into gh-pages-repo/VERSION
         run: |
           if [ "$VERSION" != "" ]; then
-             PATH="$PATH:/usr/lib/dart/bin" dart pub global run webdev build -o web:gh-pages-repo/v$VERSION
+             dart pub global run webdev build -o web:gh-pages-repo/v$VERSION
           else
              echo "::warning deploying VERSION skipped because VERSION number could not be found"
           fi

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
         with:
-          sdk: 3.7.3
+          sdk: 3.7
 
       - name: Install dependencies
         run: dart pub get

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,23 +241,23 @@ git checkout dev
 
 ### Installing Dart
 
-This project requires using Dart version **3.5.4**, not the latest version. Click on a dropdown below for installation instructions for your operating system.
+This project requires using Dart version **3.7.3**, not the latest version. Click on a dropdown below for installation instructions for your operating system.
 
 <!--TODO: Find a way to use code blocks with syntax highlighting inside <details>-->
 
 <details><summary><strong>Windows</strong></summary>
 First, install <a href="https://chocolatey.org/install">Chocolatey</a> if you haven't already. If <code>choco help</code> shows a help menu for using Chocolatey, then you've set it up correctly.
 
-Then, open a shell (cmd/Powershell) with Administrative privileges (go to Start type `cmd`, right-click on "Command Prompt", or type Powershell and right-click on "Powershell"; in both cases pick "Run as administrator") and install Dart 3.5.4:
+Then, open a shell (cmd/Powershell) with Administrative privileges (go to Start type `cmd`, right-click on "Command Prompt", or type Powershell and right-click on "Powershell"; in both cases pick "Run as administrator") and install Dart 3.7.3:
 
 <pre>
-choco install dart-sdk --version 3.5.4
+choco install dart-sdk --version 3.7.3
 </pre>
 
 To stop Chocolatey from automatically updating Dart to the latest version, pin it:
 
 <pre>
-choco pin --name="'dart-sdk'" --version="'3.5.4'"
+choco pin --name="'dart-sdk'" --version="'3.7.3'"
 </pre>
 
 </details>
@@ -267,16 +267,16 @@ First, install <a href="https://brew.sh/">Homebrew</a> if you haven't already. I
 
 It may help to run `brew tap dart-lang/dart` first.
 
-Then, install Dart 3.5.4:
+Then, install Dart 3.7.3:
 
 <pre>
-brew install dart@3.5.4
+brew install dart@3.7.3
 </pre>
 
 To stop Homebrew from automatically updating Dart to the latest version, pin it:
 
 <pre>
-brew pin dart@3.5.4
+brew pin dart@3.7.3
 </pre>
 
 If running `dart` in a terminal now does not work, you may need to follow <a href="https://docs.brew.sh/FAQ#my-mac-apps-dont-find-homebrew-utilities">these instructions</a>.
@@ -292,17 +292,17 @@ wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dea
 echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
 </pre>
 
-Then, install Dart 3.5.4:
+Then, install Dart 3.7.3:
 
 <pre>
 sudo apt-get update
-sudo apt-get install dart=3.5.4
+sudo apt-get install dart=3.7.3
 </pre>
 
 To stop apt from automatically updating Dart to the latest version, hold it:
 
 <pre>
-sudo apt-mark hold dart=3.5.4
+sudo apt-mark hold dart=3.7.3
 </pre>
 
 </details>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,23 +241,17 @@ git checkout dev
 
 ### Installing Dart
 
-This project requires using Dart version **3.7.3**, not the latest version. Click on a dropdown below for installation instructions for your operating system.
+This project requires using the latest Dart version. Click on a dropdown below for installation instructions for your operating system.
 
 <!--TODO: Find a way to use code blocks with syntax highlighting inside <details>-->
 
 <details><summary><strong>Windows</strong></summary>
 First, install <a href="https://chocolatey.org/install">Chocolatey</a> if you haven't already. If <code>choco help</code> shows a help menu for using Chocolatey, then you've set it up correctly.
 
-Then, open a shell (cmd/Powershell) with Administrative privileges (go to Start type `cmd`, right-click on "Command Prompt", or type Powershell and right-click on "Powershell"; in both cases pick "Run as administrator") and install Dart 3.7.3:
+Then, open a shell (cmd/Powershell) with Administrative privileges (go to Start type `cmd`, right-click on "Command Prompt", or type Powershell and right-click on "Powershell"; in both cases pick "Run as administrator") and install Dart:
 
 <pre>
-choco install dart-sdk --version 3.7.3
-</pre>
-
-To stop Chocolatey from automatically updating Dart to the latest version, pin it:
-
-<pre>
-choco pin --name="'dart-sdk'" --version="'3.7.3'"
+choco install dart-sdk
 </pre>
 
 </details>
@@ -267,16 +261,10 @@ First, install <a href="https://brew.sh/">Homebrew</a> if you haven't already. I
 
 It may help to run `brew tap dart-lang/dart` first.
 
-Then, install Dart 3.7.3:
+Then, install Dart:
 
 <pre>
-brew install dart@3.7.3
-</pre>
-
-To stop Homebrew from automatically updating Dart to the latest version, pin it:
-
-<pre>
-brew pin dart@3.7.3
+brew install dart
 </pre>
 
 If running `dart` in a terminal now does not work, you may need to follow <a href="https://docs.brew.sh/FAQ#my-mac-apps-dont-find-homebrew-utilities">these instructions</a>.
@@ -292,17 +280,11 @@ wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dea
 echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | sudo tee /etc/apt/sources.list.d/dart_stable.list
 </pre>
 
-Then, install Dart 3.7.3:
+Then, install Dart:
 
 <pre>
 sudo apt-get update
-sudo apt-get install dart=3.7.3
-</pre>
-
-To stop apt from automatically updating Dart to the latest version, hold it:
-
-<pre>
-sudo apt-mark hold dart=3.7.3
+sudo apt-get install dart
 </pre>
 
 </details>

--- a/lib/src/middleware/helices_positions_set_based_on_crossovers.dart
+++ b/lib/src/middleware/helices_positions_set_based_on_crossovers.dart
@@ -12,7 +12,6 @@ import '../state/domain.dart';
 import '../state/geometry.dart';
 import '../state/helix.dart';
 import '../state/position3d.dart';
-import 'package:tuple/tuple.dart';
 
 import '../state/address.dart';
 import '../actions/actions.dart' as actions;
@@ -60,7 +59,7 @@ List<actions.UndoableAction> get_helix_position_and_roll_actions(AppState state)
     var group = state.design.groups[group_name]!;
     var geometry = group.geometry ?? state.design.geometry;
     List<Helix> helices = _get_helices_to_process(state, group);
-    List<Tuple2<Address, Address>>? addresses = _get_addresses_to_process(state, helices);
+    List<(Address, Address)>? addresses = _get_addresses_to_process(state, helices);
     if (addresses == null) {
       continue;
     }
@@ -100,17 +99,17 @@ List<Helix> _get_helices_to_process(AppState state, HelixGroup group) {
 /// on the two helices it connects.
 /// returns null if two such crossovers are selected
 /// if none are selected, finds the first (one with lowest offset on helix earlier in order in [helices])
-List<Tuple2<Address, Address>>? _get_addresses_to_process(AppState state, List<Helix> helices) {
+List<(Address, Address)>? _get_addresses_to_process(AppState state, List<Helix> helices) {
   var design = state.design;
   var selected_crossovers = state.ui_state.selectables_store.selected_crossovers;
   var addresses_of_selected_crossovers_by_prev_helix_idx =
       _get_addresses_of_selected_crossovers_by_prev_helix_idx(selected_crossovers, helices, design);
 
-  List<Tuple2<Address, Address>> addresses = [];
+  List<(Address, Address)> addresses = [];
   for (int i = 0; i < helices.length - 1; i++) {
     var helix_top = helices[i];
     var helix_bot = helices[i + 1];
-    var helix_idx_top_bot = Tuple2<int, int>(helix_top.idx, helix_bot.idx);
+    (int, int) helix_idx_top_bot = (helix_top.idx, helix_bot.idx);
     var addresses_crossovers_this_helices_pair =
         addresses_of_selected_crossovers_by_prev_helix_idx[helix_idx_top_bot]!;
 
@@ -126,12 +125,11 @@ Please select only one, or select none to default to the first crossover between
       return null;
     } else if (addresses_crossovers_this_helices_pair.length == 1) {
       // first try selected crossovers between this pair of helices
-      address_top = addresses_crossovers_this_helices_pair.first.item1;
-      address_bot = addresses_crossovers_this_helices_pair.first.item2;
+      (address_top, address_bot) = addresses_crossovers_this_helices_pair.first;
     } else {
       // otherwise if none are selected, find the addresses of first crossover between this pair of helices
       // using boolean scaffold/staple settings from user to possible ignore one of those types
-      Tuple2<Address, Address>? address_top_bot;
+      (Address, Address)? address_top_bot;
       bool use_scaffold = state.ui_state.default_crossover_type_scaffold_for_setting_helix_rolls;
       bool use_staple = state.ui_state.default_crossover_type_staple_for_setting_helix_rolls;
 
@@ -151,50 +149,49 @@ Please select only one, or select none to default to the first crossover between
         util.async_alert(msg);
         return null;
       }
-      address_top = address_top_bot.item1;
-      address_bot = address_top_bot.item2;
+      (address_top, address_bot) = address_top_bot;
     }
-    addresses.add(Tuple2<Address, Address>(address_top, address_bot));
+    addresses.add((address_top, address_bot));
   }
   return addresses;
 }
 
 // "First" refers to having the lowest offset on helix h1.
-Tuple2<Address, Address>? _first_crossover_addresses_between_helices(
+(Address, Address)? _first_crossover_addresses_between_helices(
   Helix helix_top,
   Helix helix_bot,
   Design design, {
   required bool use_scaffold,
   required bool use_staple,
 }) {
-  BuiltList<Tuple2<Address, Crossover>> address_crossovers_on_top =
+  BuiltList<(Address, Crossover)> address_crossovers_on_top =
       design.address_crossover_pairs_by_helix_idx[helix_top.idx]!;
-  BuiltList<Tuple2<Address, Crossover>> address_crossovers_on_bot =
+  BuiltList<(Address, Crossover)> address_crossovers_on_bot =
       design.address_crossover_pairs_by_helix_idx[helix_bot.idx]!;
 
   // if not using scaffold or crossovers when finding leftmost, filter those out
   if (!use_scaffold) {
     address_crossovers_on_bot =
         address_crossovers_on_bot
-            .where((address_crossover) => !address_crossover.item2.is_scaffold)
+            .where((address_crossover) => !address_crossover.$2.is_scaffold)
             .toBuiltList();
   }
   if (!use_staple) {
     address_crossovers_on_bot =
         address_crossovers_on_bot
-            .where((address_crossover) => address_crossover.item2.is_scaffold)
+            .where((address_crossover) => address_crossover.$2.is_scaffold)
             .toBuiltList();
   }
 
   // find first crossover on h1 that also goes to h2
-  for (Tuple2<Address, Crossover> address_crossover_top in address_crossovers_on_top) {
-    Crossover crossover_top = address_crossover_top.item2;
+  for ((Address, Crossover) address_crossover_top in address_crossovers_on_top) {
+    Crossover crossover_top = address_crossover_top.$2;
     for (var address_crossover_bot in address_crossovers_on_bot) {
-      var crossover_bot = address_crossover_bot.item2;
+      var crossover_bot = address_crossover_bot.$2;
       if (crossover_bot == crossover_top) {
-        Address address_top = address_crossover_top.item1;
-        Address address_bot = address_crossover_bot.item1;
-        return Tuple2<Address, Address>(address_top, address_bot);
+        Address address_top = address_crossover_top.$1;
+        Address address_bot = address_crossover_bot.$1;
+        return (address_top, address_bot);
       }
     }
   }
@@ -213,20 +210,20 @@ Tuple2<Address, Address>? _first_crossover_addresses_between_helices(
 //   (7,5): [... (offset,crossover) pairs between 5 and 7, offset is where crossover touches helix 7]
 // }
 // Sorts each list by the offset on its first helix (first meaning first in order in helices)
-Map<Tuple2<int, int>, List<Tuple2<Address, Address>>> _get_addresses_of_selected_crossovers_by_prev_helix_idx(
+Map<(int, int), List<(Address, Address)>> _get_addresses_of_selected_crossovers_by_prev_helix_idx(
   BuiltSet<Crossover> selected_crossovers,
   List<Helix> helices,
   Design design,
 ) {
   // this is essentially what we return, but each crossover also carries with it the start offset of
   // the helix earlier in the ordering, which helps to sort the lists of crossovers before returning
-  Map<Tuple2<int, int>, List<Tuple2<Address, Address>>> addresses_top_bot_crossovers = {};
+  Map<(int, int), List<(Address, Address)>> addresses_top_bot_crossovers = {};
 
   // initialize internal map to have empty lists
   for (int i = 0; i < helices.length - 1; i++) {
     int idx1 = helices[i].idx;
     int idx2 = helices[i + 1].idx;
-    var pair_idxs = Tuple2<int, int>(idx1, idx2);
+    (int, int) pair_idxs = (idx1, idx2);
     addresses_top_bot_crossovers[pair_idxs] = [];
   }
 
@@ -240,8 +237,8 @@ Map<Tuple2<int, int>, List<Tuple2<Address, Address>>> _get_addresses_of_selected
     var next_dom = strand.substrands[crossover.next_domain_idx] as Domain;
     var prev_idx = prev_dom.helix;
     var next_idx = next_dom.helix;
-    var pair_idxs = Tuple2<int, int>(prev_idx, next_idx);
-    var pair_idxs_rev = Tuple2<int, int>(next_idx, prev_idx);
+    (int, int) pair_idxs = (prev_idx, next_idx);
+    (int, int) pair_idxs_rev = (next_idx, prev_idx);
 
     if (addresses_top_bot_crossovers.containsKey(pair_idxs) ||
         addresses_top_bot_crossovers.containsKey(pair_idxs_rev)) {
@@ -280,7 +277,7 @@ Map<Tuple2<int, int>, List<Tuple2<Address, Address>>> _get_addresses_of_selected
       }
       var address_top = Address(helix_idx: dom_top.helix, offset: offset_top, forward: dom_top.forward);
       var address_bot = Address(helix_idx: dom_bot.helix, offset: offset_bot, forward: dom_bot.forward);
-      addresses_top_bot_crossovers[pair_idxs]!.add(Tuple2<Address, Address>(address_top, address_bot));
+      addresses_top_bot_crossovers[pair_idxs]!.add((address_top, address_bot));
     }
   }
 
@@ -307,7 +304,7 @@ List<RollXY> _calculate_rolls_and_positions(
   Design design,
   Geometry geometry,
   List<Helix> helices,
-  List<Tuple2<Address, Address>> addresses,
+  List<(Address, Address)> addresses,
   double first_roll,
 ) {
   assert(helices.length == addresses.length + 1);
@@ -317,8 +314,8 @@ List<RollXY> _calculate_rolls_and_positions(
   List<RollXY> rollxys = [RollXY(roll: first_roll, x: x, y: y)];
 
   for (int i = 0; i < addresses.length; i++) {
-    var address_top = addresses[i].item1;
-    var address_bot = addresses[i].item2;
+    var (address_top, address_bot) = addresses[i];
+
     var roll = rollxys[i].roll;
     var x = rollxys[i].x;
     var y = rollxys[i].y;

--- a/lib/src/middleware/oxdna_export.dart
+++ b/lib/src/middleware/oxdna_export.dart
@@ -15,7 +15,6 @@ import 'package:scadnano/src/state/grid.dart';
 import 'package:scadnano/src/state/loopout.dart';
 import 'package:scadnano/src/state/position3d.dart';
 import 'package:scadnano/src/state/strand.dart';
-import 'package:tuple/tuple.dart';
 import '../state/app_state.dart';
 import '../actions/actions.dart' as actions;
 import '../state/helix.dart';
@@ -41,9 +40,7 @@ First select some strands, or choose Export🡒oxDNA to export all strands in th
     }
 
     if (action is actions.OxdnaExport) {
-      Tuple2<String, String> dat_top = to_oxdna_format(state.design, strands_to_export);
-      String dat = dat_top.item1;
-      String top = dat_top.item2;
+      var (dat, top) = to_oxdna_format(state.design, strands_to_export); // (String, String)
 
       String default_filename = state.ui_state.loaded_filename;
       String default_filename_dat = path.setExtension(default_filename, '.dat');
@@ -152,11 +149,9 @@ String to_oxview_format(Design design, List<Strand> strands_to_export) {
   );
   for (int helix in base_pairs_map.keys) {
     for (var offset_dom_strands in base_pairs_map[helix]!) {
-      int offset = offset_dom_strands.item1;
-      Domain domain1 = offset_dom_strands.item2;
-      Domain domain2 = offset_dom_strands.item3;
-      Strand sc_strand1 = offset_dom_strands.item4;
-      Strand sc_strand2 = offset_dom_strands.item5;
+      // (int, Domain, Domain, Strand, Strand)
+      var (offset, domain1, domain2, sc_strand1, sc_strand2) = offset_dom_strands;
+      
       Map<String, dynamic> oxv_strand1 = oxview_strand_map[sc_strand1.id];
       Map<String, dynamic> oxv_strand2 = oxview_strand_map[sc_strand2.id];
       int d1 = sc_strand1.domain_offset_to_strand_dna_idx(domain1, offset, false);
@@ -195,10 +190,9 @@ String to_oxview_format(Design design, List<Strand> strands_to_export) {
   return content;
 }
 
-Tuple2<String, String> to_oxdna_format(Design design, [List<Strand>? strands_to_export = null]) {
+(String, String) to_oxdna_format(Design design, [List<Strand>? strands_to_export = null]) {
   OxdnaSystem system = convert_design_to_oxdna_system(design, strands_to_export);
-  Tuple2<String, String> dat_top = system.oxdna_output();
-  return dat_top;
+  return system.oxdna_output();
 }
 
 class OxdnaVector {
@@ -320,7 +314,7 @@ class OxdnaSystem {
     }
   }
 
-  Tuple2<String, String> oxdna_output() {
+  (String, String) oxdna_output() {
     OxdnaVector bbox = compute_bounding_box();
 
     List<String> dat_list = ['t = 0', 'b = ${bbox.x} ${bbox.y} ${bbox.z}', 'E = 0 0 0'];
@@ -358,14 +352,14 @@ class OxdnaSystem {
 
     top = '${nuc_count} ${strand_count}\n' + top;
 
-    return Tuple2<String, String>(dat, top);
+    return (dat, top);
   }
 }
 
 const NM_TO_OX_UNITS = 1.0 / 0.8518;
 
 // returns the origin, forward, and normal vectors of a helix
-Tuple3<OxdnaVector, OxdnaVector, OxdnaVector> oxdna_get_helix_vectors(Design design, Helix helix) {
+(OxdnaVector, OxdnaVector, OxdnaVector) oxdna_get_helix_vectors(Design design, Helix helix) {
   /*
   TODO: document functions/methods with docstrings
   :param helix:
@@ -426,7 +420,7 @@ Tuple3<OxdnaVector, OxdnaVector, OxdnaVector> oxdna_get_helix_vectors(Design des
 
   var origin = (position_in_helix_group_rotated + helix_group_offset) * NM_TO_OX_UNITS;
 
-  return Tuple3<OxdnaVector, OxdnaVector, OxdnaVector>(origin, forward, normal);
+  return (origin, forward, normal);
 }
 
 OxdnaSystem convert_design_to_oxdna_system(Design design, [List<Strand>? strands_to_export = null]) {
@@ -472,7 +466,7 @@ OxdnaSystem convert_design_to_oxdna_system(Design design, [List<Strand>? strands
   };
 
   for (var strand in strands_to_export) {
-    List<Tuple2<OxdnaStrand, bool>> strand_domains = [];
+    List<(OxdnaStrand, bool)> strand_domains = [];
     for (int ss_idx = 0; ss_idx < strand.substrands.length; ss_idx++) {
       var domain = strand.substrands[ss_idx];
       var ox_strand = OxdnaStrand();
@@ -487,10 +481,7 @@ OxdnaSystem convert_design_to_oxdna_system(Design design, [List<Strand>? strands
         var group = design.groups[helix.group]!;
         var geometry = group.geometry ?? design.geometry;
         var step_rot = -360 / geometry.bases_per_turn;
-        var origin_forward_normal = helix_vectors[helix.idx]!;
-        var origin = origin_forward_normal.item1;
-        var forward = origin_forward_normal.item2;
-        var normal = origin_forward_normal.item3;
+        var (origin, forward, normal) = helix_vectors[helix.idx]!; // (OxdnaVector, OxdnaVector, OxdnaVector)
 
         if (!domain.forward) {
           normal = normal.rotate(-geometry.minor_groove_angle, forward);
@@ -545,7 +536,7 @@ OxdnaSystem convert_design_to_oxdna_system(Design design, [List<Strand>? strands
         if (!domain.forward) {
           ox_strand.nucleotides = List<OxdnaNucleotide>.from(ox_strand.nucleotides.reversed);
         }
-        strand_domains.add(Tuple2<OxdnaStrand, bool>(ox_strand, false));
+        strand_domains.add((ox_strand, false));
         // because we need to know the positions of nucleotides before and after the loopout
         // we temporarily store domain strands with a boolean that is true if it's a loopout
         // handle loopouts
@@ -560,7 +551,7 @@ OxdnaSystem convert_design_to_oxdna_system(Design design, [List<Strand>? strands
           var nuc = OxdnaNucleotide(center, normal, forward, base);
           ox_strand.nucleotides.add(nuc);
         }
-        strand_domains.add(Tuple2<OxdnaStrand, bool>(ox_strand, true));
+        strand_domains.add((ox_strand, true));
       } else if (domain is Extension) {
         bool is_5p = ss_idx == 0;
         var helix = design.helices[domain.adjacent_domain.helix]!;
@@ -575,7 +566,7 @@ OxdnaSystem convert_design_to_oxdna_system(Design design, [List<Strand>? strands
           mod_map: mod_map,
         );
         ox_strand.nucleotides.addAll(nucleotides);
-        strand_domains.add(Tuple2<OxdnaStrand, bool>(ox_strand, false));
+        strand_domains.add((ox_strand, false));
       } else {
         throw AssertionError('unreachable');
       }
@@ -584,12 +575,11 @@ OxdnaSystem convert_design_to_oxdna_system(Design design, [List<Strand>? strands
     var sstrand = OxdnaStrand();
     // process loopouts and join strands
     for (int i = 0; i < strand_domains.length; i++) {
-      var dstrand_is_loopout = strand_domains[i];
-      var dstrand = dstrand_is_loopout.item1;
-      var is_loopout = dstrand_is_loopout.item2;
+      var (dstrand, is_loopout) = strand_domains[i]; // (OxdnaStrand, bool)
+
       if (is_loopout) {
-        var prev_nuc = strand_domains[i - 1].item1.nucleotides.last;
-        var next_nuc = strand_domains[i + 1].item1.nucleotides.first;
+        var prev_nuc = strand_domains[i - 1].$1.nucleotides.last;
+        var next_nuc = strand_domains[i + 1].$1.nucleotides.first;
 
         int strand_length = dstrand.nucleotides.length;
 
@@ -618,7 +608,7 @@ List<OxdnaNucleotide> _compute_extension_nucleotides({
   required Geometry geometry,
   required Strand strand,
   required bool is_5p,
-  required Map<int, Tuple3<OxdnaVector, OxdnaVector, OxdnaVector>> helix_vectors,
+  required Map<int, (OxdnaVector, OxdnaVector, OxdnaVector)> helix_vectors,
   required Map<int, List<int>> mod_map,
 }) {
   var step_rot = -360 / geometry.bases_per_turn;
@@ -628,9 +618,8 @@ List<OxdnaNucleotide> _compute_extension_nucleotides({
   var offset = is_5p ? adj_dom.offset_5p : adj_dom.offset_3p; // offset of attached end of domain
 
   var origin_forward_normal = helix_vectors[adj_dom.helix]!;
-  var origin_ = origin_forward_normal.item1;
-  var forward = origin_forward_normal.item2;
-  var normal = origin_forward_normal.item3;
+
+  var (origin_, forward, normal) = origin_forward_normal; // (OxdnaVector, OxdnaVector, OxdnaVector)
 
   if (!adj_dom.forward) {
     normal = normal.rotate(-geometry.minor_groove_angle, forward);

--- a/lib/src/middleware/oxdna_export.dart
+++ b/lib/src/middleware/oxdna_export.dart
@@ -151,7 +151,7 @@ String to_oxview_format(Design design, List<Strand> strands_to_export) {
     for (var offset_dom_strands in base_pairs_map[helix]!) {
       // (int, Domain, Domain, Strand, Strand)
       var (offset, domain1, domain2, sc_strand1, sc_strand2) = offset_dom_strands;
-      
+
       Map<String, dynamic> oxv_strand1 = oxview_strand_map[sc_strand1.id];
       Map<String, dynamic> oxv_strand2 = oxview_strand_map[sc_strand2.id];
       int d1 = sc_strand1.domain_offset_to_strand_dna_idx(domain1, offset, false);

--- a/lib/src/middleware/oxview_update_view.dart
+++ b/lib/src/middleware/oxview_update_view.dart
@@ -17,7 +17,6 @@ import 'package:scadnano/src/state/grid.dart';
 import 'package:scadnano/src/state/loopout.dart';
 import 'package:scadnano/src/state/position3d.dart';
 import 'package:scadnano/src/state/strand.dart';
-import 'package:tuple/tuple.dart';
 import '../state/app_state.dart';
 import '../actions/actions.dart' as actions;
 import '../state/helix.dart';
@@ -67,9 +66,7 @@ void update_oxview_view(Design design, [IFrameElement? frame = null]) {
   List<Strand> strands_to_export = design.strands.toList();
 
   // String content = to_oxview_format(design, strands_to_export);
-  Tuple2<String, String> dat_top = to_oxdna_format(design, strands_to_export);
-  String dat = dat_top.item1;
-  String top = dat_top.item2;
+  var (dat, top) = to_oxdna_format(design, strands_to_export); // (String, String)
 
   Blob blob_dat = new Blob([dat], blob_type_to_string(BlobType.text));
   Blob blob_top = new Blob([top], blob_type_to_string(BlobType.text));

--- a/lib/src/middleware/reselect_moved_dna_extension_ends.dart
+++ b/lib/src/middleware/reselect_moved_dna_extension_ends.dart
@@ -2,7 +2,6 @@ import 'package:react/react.dart';
 import 'package:redux/redux.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:scadnano/src/state/extension.dart';
-import 'package:tuple/tuple.dart';
 
 import '../state/domain.dart';
 import '../state/dna_end.dart';

--- a/lib/src/middleware/selections_intersect_box_compute.dart
+++ b/lib/src/middleware/selections_intersect_box_compute.dart
@@ -5,7 +5,6 @@ import 'dart:svg' as svg;
 import 'package:built_collection/built_collection.dart';
 import 'package:redux/redux.dart';
 import 'package:scadnano/src/state/selection_rope.dart';
-import 'package:tuple/tuple.dart';
 
 import '../state/select_mode.dart';
 import '../state/selection_box.dart';

--- a/lib/src/middleware/system_clipboard.dart
+++ b/lib/src/middleware/system_clipboard.dart
@@ -127,8 +127,7 @@ bool paste_is_impossible_from_clipboard(String clipboard_content, bool in_browse
   var strands_and_helices_view_order = parse_strands_and_helices_view_order_from_clipboard(clipboard_content);
   if (strands_and_helices_view_order == null) return true;
 
-  List<Strand> strands = strands_and_helices_view_order.item1;
-  List<int>? helices_view_order = strands_and_helices_view_order.item2;
+  var (strands, helices_view_order) = strands_and_helices_view_order; // (List<Strand>, List<int>?)
 
   if (strands.isEmpty) return true;
 

--- a/lib/src/reducers/app_ui_state_reducer.dart
+++ b/lib/src/reducers/app_ui_state_reducer.dart
@@ -12,7 +12,6 @@ import 'package:scadnano/src/state/strand.dart';
 import 'package:scadnano/src/state/copy_info.dart';
 import 'package:scadnano/src/state/substrand.dart';
 import 'package:scadnano/src/util.dart';
-import 'package:tuple/tuple.dart';
 import '../reducers/context_menu_reducer.dart';
 import '../state/example_designs.dart';
 import '../state/grid_position.dart';

--- a/lib/src/reducers/assign_or_remove_dna_reducer.dart
+++ b/lib/src/reducers/assign_or_remove_dna_reducer.dart
@@ -4,7 +4,6 @@ import '../state/domain.dart';
 import '../state/design.dart';
 import '../state/loopout.dart';
 import '../state/substrand.dart';
-import 'package:tuple/tuple.dart';
 
 import '../state/strand.dart';
 import '../state/app_state.dart';
@@ -106,11 +105,10 @@ BuiltList<Strand> assign_dna_reducer(BuiltList<Strand> strands, AppState state, 
 }
 
 // Lexicographically compare (start,end) overlap coordinates of o1 and o2.
-int compare_overlap(Tuple2<Tuple2<int, int>, Domain> o1, Tuple2<Tuple2<int, int>, Domain> o2) {
-  int o1_start = o1.item1.item1;
-  int o1_end = o1.item1.item2;
-  int o2_start = o2.item1.item1;
-  int o2_end = o2.item1.item2;
+int compare_overlap(((int, int), Domain) o1, ((int, int), Domain) o2) {
+  var (o1_start, o1_end) = o1.$1; // (int, int)
+  var (o2_start, o2_end) = o2.$1; // (int, int)
+
   if (o1_start != o2_start) {
     return o1_start - o2_start;
   } else {
@@ -177,11 +175,11 @@ String compute_dna_complement_from(
 
       int helix_idx = domain_to.helix;
       List<Domain> domains_on_helix_from = strand_from.domains_on_helix[helix_idx]?.toList() ?? [];
-      List<Tuple2<Tuple2<int, int>, Domain>> overlaps = [];
+      List<((int, int), Domain)> overlaps = [];
       for (var domain_from in domains_on_helix_from) {
         if (domain_to != domain_from && domain_to.overlaps(domain_from)) {
-          Tuple2<int, int> overlap = domain_to.compute_overlap(domain_from)!;
-          overlaps.add(Tuple2<Tuple2<int, int>, Domain>(overlap, domain_from));
+          (int, int) overlap = domain_to.compute_overlap(domain_from)!;
+          overlaps.add((overlap, domain_from));
         }
       }
       overlaps.sort(compare_overlap);
@@ -190,9 +188,8 @@ String compute_dna_complement_from(
       int start_idx = domain_to.start;
       // repeatedly insert wildcards into gaps, then reverse WC complement
       for (var overlap in overlaps) {
-        int overlap_left = overlap.item1.item1;
-        int overlap_right = overlap.item1.item2;
-        Domain substrand_from = overlap.item2;
+        var (overlap_left, overlap_right) = overlap.$1; // (int, int)
+        Domain substrand_from = overlap.$2;
         // wildcards = DNA_base_wildcard * (overlap_left - start_idx)
         int num_wildcard_bases = domain_to.dna_length_in(start_idx, overlap_left - 1);
         String wildcards = constants.DNA_BASE_WILDCARD * num_wildcard_bases;

--- a/lib/src/reducers/insertion_deletion_reducer.dart
+++ b/lib/src/reducers/insertion_deletion_reducer.dart
@@ -1,7 +1,6 @@
 import 'package:built_collection/built_collection.dart';
 import 'package:redux/redux.dart';
 import 'package:scadnano/src/state/app_state.dart';
-import 'package:tuple/tuple.dart';
 import '../actions/actions.dart' as actions;
 import '../state/domain.dart';
 import '../state/strand.dart';

--- a/lib/src/reducers/nick_ligate_join_by_crossover_reducers.dart
+++ b/lib/src/reducers/nick_ligate_join_by_crossover_reducers.dart
@@ -5,7 +5,6 @@ import 'package:react/react.dart';
 import 'package:scadnano/src/reducers/change_loopout_ext_properties.dart';
 import 'package:scadnano/src/state/linker.dart';
 import 'package:scadnano/src/state/potential_crossover.dart';
-import 'package:tuple/tuple.dart';
 
 import '../state/crossover.dart';
 import '../state/design.dart';
@@ -467,7 +466,7 @@ BuiltList<Strand> join_strands_by_multiple_crossovers_reducer(
   AppState state,
   actions.JoinStrandsByMultipleCrossovers action,
 ) {
-  List<Tuple2<DNAEnd, DNAEnd>> end_pairs = find_end_pairs_to_connect(
+  List<(DNAEnd, DNAEnd)> end_pairs = find_end_pairs_to_connect(
     state.design,
     state.ui_state.selectables_store.selected_dna_ends.toList(),
   );
@@ -476,8 +475,7 @@ BuiltList<Strand> join_strands_by_multiple_crossovers_reducer(
   List<Address> addresses_from = [];
   List<Address> addresses_to = [];
   for (var end_pair in end_pairs) {
-    var end1 = end_pair.item1;
-    var end2 = end_pair.item2;
+    var (end1, end2) = end_pair; // (DNAEnd, DNAEnd)
     var end_from = end1.is_3p ? end1 : end2;
     var end_to = end1.is_3p ? end2 : end1;
     addresses_from.add(state.design.end_to_address[end_from]!);
@@ -511,7 +509,7 @@ Strand? _strand_with_end_address(Iterable<Strand> strands, Address address, bool
 
 /// find which pairs of ends among [selected_ends] to connect by Crossovers, and dispatch BatchAction
 /// to connect them
-List<Tuple2<DNAEnd, DNAEnd>> find_end_pairs_to_connect(Design design, List<DNAEnd> selected_ends) {
+List<(DNAEnd, DNAEnd)> find_end_pairs_to_connect(Design design, List<DNAEnd> selected_ends) {
   Map<DNAEnd, Domain> all_domains = {for (var end in selected_ends) end: design.end_to_domain[end]!};
 
   // group according to HelixGroups
@@ -528,7 +526,7 @@ List<Tuple2<DNAEnd, DNAEnd>> find_end_pairs_to_connect(Design design, List<DNAEn
   }
 
   // find pairs of ends to connect
-  List<Tuple2<DNAEnd, DNAEnd>> end_pairs_to_connect = [];
+  List<(DNAEnd, DNAEnd)> end_pairs_to_connect = [];
   for (var group_name in design.groups.keys) {
     // BuiltList<int> helices_view_order = design.groups[group_name].helices_view_order;
     BuiltMap<int, int> helices_view_order_inverse = design.groups[group_name]!.helices_view_order_inverse;
@@ -549,7 +547,7 @@ List<Tuple2<DNAEnd, DNAEnd>> find_end_pairs_to_connect(Design design, List<DNAEn
 
 /// find end pairs to connect according to algorithm described here:
 /// https://github.com/UC-Davis-molecular-computing/scadnano/issues/581
-List<Tuple2<DNAEnd, DNAEnd>> find_end_pairs_to_connect_in_group(
+List<(DNAEnd, DNAEnd)> find_end_pairs_to_connect_in_group(
   List<DNAEnd> ends,
   Map<DNAEnd, Domain> domains_by_end,
   BuiltMap<int, int> helices_view_order_inverse,
@@ -581,7 +579,7 @@ List<Tuple2<DNAEnd, DNAEnd>> find_end_pairs_to_connect_in_group(
     ends_by_offset[end.offset_inclusive]!.add(end);
   }
 
-  List<Tuple2<DNAEnd, DNAEnd>> end_pairs = [];
+  List<(DNAEnd, DNAEnd)> end_pairs = [];
 
   for (int offset in ends_by_offset.keys) {
     // remember which ends have been paired with this offset, so we don't pick any twice
@@ -594,7 +592,7 @@ List<Tuple2<DNAEnd, DNAEnd>> find_end_pairs_to_connect_in_group(
       }
       var end2 = find_paired_end(end1, i + 1, ends_with_offset, already_chosen_ends, domains_by_end);
       if (end2 != null) {
-        var end_pair = Tuple2<DNAEnd, DNAEnd>(end1, end2);
+        (DNAEnd, DNAEnd) end_pair = (end1, end2);
         end_pairs.add(end_pair);
         already_chosen_ends.add(end1);
         already_chosen_ends.add(end2);

--- a/lib/src/reducers/strands_copy_info_reducer.dart
+++ b/lib/src/reducers/strands_copy_info_reducer.dart
@@ -3,7 +3,6 @@ import 'dart:html';
 
 import 'package:built_collection/built_collection.dart';
 import 'package:scadnano/src/state/modification.dart';
-import 'package:tuple/tuple.dart';
 
 import '../state/copy_info.dart';
 import '../state/strands_move.dart';
@@ -40,8 +39,7 @@ CopyInfo? manual_paste_initiate_reducer(CopyInfo? _, AppState state, actions.Man
     return null;
   }
 
-  List<Strand> strands = strands_and_helices_view_order.item1;
-  List<int>? helices_view_order = strands_and_helices_view_order.item2;
+  var (strands, helices_view_order) = strands_and_helices_view_order; // (List<Strand>, List<int>?)
 
   if (strands.isEmpty) return null;
   // indicates helices came from more than one HelixGroup, so no way to paste
@@ -62,8 +60,7 @@ CopyInfo? autopaste_initiate_reducer(CopyInfo? copy_info, AppState state, action
     return null;
   }
 
-  List<Strand> strands = strands_and_helices_view_order.item1;
-  List<int>? helices_view_order = strands_and_helices_view_order.item2;
+  var (strands, helices_view_order) = strands_and_helices_view_order; // (List<Strand>, List<int>?)
 
   if (strands.isEmpty) return null;
   // indicates helices came from more than one HelixGroup, so no way to paste
@@ -79,7 +76,7 @@ CopyInfo? autopaste_initiate_reducer(CopyInfo? copy_info, AppState state, action
 }
 
 /// returns null on JSON decode error
-Tuple2<List<Strand>, List<int>?>? parse_strands_and_helices_view_order_from_clipboard(
+(List<Strand>, List<int>?)? parse_strands_and_helices_view_order_from_clipboard(
   String clipboard_content,
 ) {
   String error_msg =
@@ -160,7 +157,7 @@ Tuple2<List<Strand>, List<int>?>? parse_strands_and_helices_view_order_from_clip
     strands.add(strand);
   }
 
-  return Tuple2<List<Strand>, List<int>?>(strands, helices_view_order);
+  return (strands, helices_view_order);
 }
 
 // need to pass in helices_view_order from clipboard since these strands may be from a different design

--- a/lib/src/reducers/strands_copy_info_reducer.dart
+++ b/lib/src/reducers/strands_copy_info_reducer.dart
@@ -76,9 +76,7 @@ CopyInfo? autopaste_initiate_reducer(CopyInfo? copy_info, AppState state, action
 }
 
 /// returns null on JSON decode error
-(List<Strand>, List<int>?)? parse_strands_and_helices_view_order_from_clipboard(
-  String clipboard_content,
-) {
+(List<Strand>, List<int>?)? parse_strands_and_helices_view_order_from_clipboard(String clipboard_content) {
   String error_msg =
       'no strand info found on system clipboard, so nothing to paste; '
       'content of system clipboard: "${clipboard_content}"';

--- a/lib/src/reducers/strands_reducer.dart
+++ b/lib/src/reducers/strands_reducer.dart
@@ -9,7 +9,6 @@ import 'package:scadnano/src/state/extension.dart';
 import 'package:scadnano/src/state/loopout.dart';
 import 'package:scadnano/src/state/modification.dart';
 import 'package:scadnano/src/state/selectable.dart';
-import 'package:tuple/tuple.dart';
 
 import 'assign_domain_names_reducer.dart';
 import 'strands_move_reducer.dart' as strands_move_reducer;
@@ -408,8 +407,8 @@ BuiltList<Strand> strands_dna_ends_move_commit_reducer(
   for (var strand in strands_affected) {
     int strand_idx = strands.indexOf(strand);
     var ret = single_strand_dna_ends_commit_stop_reducer(strand, move, state.design);
-    strand = ret.item1;
-    records.addAll(ret.item2);
+    strand = ret.$1;
+    records.addAll(ret.$2);
     strand = strand.initialize();
     strands_builder[strand_idx] = strand;
   }
@@ -469,8 +468,8 @@ BuiltList<Strand> strands_dna_extensions_move_commit_reducer(
     Extension ext_new = extension.rebuild(
       (b) =>
           b
-            ..display_length = length_and_angle.item1
-            ..display_angle = length_and_angle.item2,
+            ..display_length = length_and_angle.$1
+            ..display_angle = length_and_angle.$2,
     );
 
     substrands_builder[substrand_idx] = ext_new;
@@ -491,7 +490,7 @@ class InsertionDeletionRecord {
       'InsertionDeletionRecord(offset=${offset}, strand_idx=$strand_idx, substrand_idx=$substrand_idx)';
 }
 
-Tuple2<Strand, List<InsertionDeletionRecord>> single_strand_dna_ends_commit_stop_reducer(
+(Strand, List<InsertionDeletionRecord>) single_strand_dna_ends_commit_stop_reducer(
   Strand strand,
   DNAEndsMove all_move,
   Design design,
@@ -552,7 +551,7 @@ Tuple2<Strand, List<InsertionDeletionRecord>> single_strand_dna_ends_commit_stop
     substrands[i] = new_substrand;
   }
   strand = strand.rebuild((b) => b..substrands.replace(substrands));
-  return Tuple2<Strand, List<InsertionDeletionRecord>>(strand, records);
+  return (strand, records);
 }
 
 List<int> get_remaining_deletions(Domain substrand, int new_offset, DNAEnd dnaend) =>

--- a/lib/src/serializers.dart
+++ b/lib/src/serializers.dart
@@ -9,7 +9,6 @@ import 'package:scadnano/src/dna_file_type.dart';
 import 'package:scadnano/src/state/base_pair_display_type.dart';
 import 'package:scadnano/src/state/dna_extensions_move.dart';
 import 'package:scadnano/src/state/undo_redo.dart';
-import 'package:tuple/tuple.dart';
 
 import 'state/dna_assign_options.dart';
 import 'state/domains_move.dart';

--- a/lib/src/state/app_ui_state.dart
+++ b/lib/src/state/app_ui_state.dart
@@ -7,7 +7,6 @@ import 'package:built_value/built_value.dart';
 import 'package:scadnano/src/state/design_side_rotation_data.dart';
 import 'package:scadnano/src/state/modification.dart';
 import 'package:scadnano/src/state/copy_info.dart';
-import 'package:tuple/tuple.dart';
 import '../actions/actions.dart' as actions;
 import '../state/local_storage_design_choice.dart';
 

--- a/lib/src/state/design.dart
+++ b/lib/src/state/design.dart
@@ -1285,11 +1285,11 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
     bool using_groups = json_map.containsKey(constants.groups_key);
 
     // (Map<int, HelixBuilder>, Map<String, HelixPitchYaw>, Map<HelixPitchYaw, List<HelixBuilder>>)
-    var (
-      helix_builders_map,
-      group_to_pitch_yaw,
-      pitch_yaw_to_helices
-    ) = _helices_from_json(json_map, invert_y, geometry);
+    var (helix_builders_map, group_to_pitch_yaw, pitch_yaw_to_helices) = _helices_from_json(
+      json_map,
+      invert_y,
+      geometry,
+    );
 
     Map<String, HelixGroupBuilder> group_builders_map = _groups_from_json(
       json_map,
@@ -1357,10 +1357,12 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
     );
 
     // (Map<int, HelixBuilder>, Map<String, HelixGroupBuilder>)
-    var (
-      helix_builders_map,
-      group_builders_map
-    ) = Design._helices_and_groups_from_json(json_map, invert_y, position_x_z_should_swap, geometry);
+    var (helix_builders_map, group_builders_map) = Design._helices_and_groups_from_json(
+      json_map,
+      invert_y,
+      position_x_z_should_swap,
+      geometry,
+    );
 
     // strands
     List<Strand> strands = [];
@@ -2271,7 +2273,8 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
     for (int idx in this.helices.keys) {
       List<(int, Domain, Domain, Strand, Strand)> offsets_and_domain_strand = [];
       List<(Domain, Domain)> overlapping_domains = find_overlapping_domains_on_helix(idx);
-      for (var (dom1, dom2) in overlapping_domains) { // (Domain, Domain)
+      for (var (dom1, dom2) in overlapping_domains) {
+        // (Domain, Domain)
         if (!allow_unassigned_dna && (dom1.dna_sequence == null || dom2.dna_sequence == null)) {
           // If not allowing unassigned DNA, then skip if either has no DNA sequence
           continue;
@@ -2312,15 +2315,13 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
                       base1 == constants.DNA_BASE_WILDCARD ||
                       base2 == constants.DNA_BASE_WILDCARD)) ||
               util.reverse_complementary(base1, base2, allow_wildcard: true)) {
-            offsets_and_domain_strand.add(
-              (
-                offset,
-                dom1,
-                dom2,
-                this.substrand_to_strand[dom1]!,
-                this.substrand_to_strand[dom2]!,
-              ),
-            );
+            offsets_and_domain_strand.add((
+              offset,
+              dom1,
+              dom2,
+              this.substrand_to_strand[dom1]!,
+              this.substrand_to_strand[dom2]!,
+            ));
           }
         }
       }
@@ -2517,11 +2518,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
     if (id_from == -1 && base_from == -1 && id_to == -1 && base_to == -1) return null;
 
     // (int, int, bool)
-    var (
-      strand_5_end_helix,
-      strand_5_end_base,
-      is_circular
-    ) = Design._cadnano_v2_import_find_5_end(
+    var (strand_5_end_helix, strand_5_end_base, is_circular) = Design._cadnano_v2_import_find_5_end(
       vstrands,
       strand_type,
       helix_num,

--- a/lib/src/state/design.dart
+++ b/lib/src/state/design.dart
@@ -2,7 +2,6 @@ import 'dart:collection';
 import 'dart:convert';
 import 'dart:math';
 
-import 'package:tuple/tuple.dart';
 import 'package:collection/collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_collection/built_collection.dart';
@@ -262,7 +261,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
       for (int idx in address_crossover_pairs_by_helix_idx.keys)
         idx:
             address_crossover_pairs_by_helix_idx[idx]!
-                .map((address_crossover_pair) => address_crossover_pair.item2)
+                .map((address_crossover_pair) => address_crossover_pair.$2)
                 .toBuiltList(),
     };
 
@@ -273,10 +272,10 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
   // offset is inclusive on either end. This ensures that each half of a double crossover actual
   // has different offsets, and the leftmost one is considered smaller.
   @memoized
-  BuiltMap<int, BuiltList<Tuple2<Address, Crossover>>> get address_crossover_pairs_by_helix_idx {
+  BuiltMap<int, BuiltList<(Address, Crossover)>> get address_crossover_pairs_by_helix_idx {
     // this is essentially what we return, but each crossover also carries with it the start offset of
     // the helix earlier in the ordering, which helps to sort the lists of crossovers before returning
-    Map<int, List<Tuple2<Address, Crossover>>> address_crossover_pairs = {};
+    Map<int, List<(Address, Crossover)>> address_crossover_pairs = {};
 
     // initialize internal map to have empty lists
     for (int helix_idx in helices.keys) {
@@ -290,7 +289,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
         var next_dom = strand.substrands[crossover.next_domain_idx] as Domain;
         bool is_prev = true;
         for (var dom in [prev_dom, next_dom]) {
-          List<Tuple2<Address, Crossover>> address_crossover_pair_list = address_crossover_pairs[dom.helix]!;
+          List<(Address, Crossover)> address_crossover_pair_list = address_crossover_pairs[dom.helix]!;
           int offset;
           // ugg, this logic is ugly. Here's the various possibilities
           /*
@@ -305,7 +304,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
             offset = dom.start;
           }
           var address = Address(helix_idx: dom.helix, offset: offset, forward: dom.forward);
-          var pair = Tuple2<Address, Crossover>(address, crossover);
+          (Address, Crossover) pair = (address, crossover);
           address_crossover_pair_list.add(pair);
           is_prev = false;
         }
@@ -314,16 +313,16 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
 
     // sort by offset where it intersects the helix
     for (var pair_idxs in address_crossover_pairs.keys) {
-      List<Tuple2<Address, Crossover>> start_crossover_pair_list = address_crossover_pairs[pair_idxs]!;
+      List<(Address, Crossover)> start_crossover_pair_list = address_crossover_pairs[pair_idxs]!;
       start_crossover_pair_list.sort((address_crossover_pair1, address_crossover_pair2) {
-        Address add1 = address_crossover_pair1.item1;
-        Address add2 = address_crossover_pair2.item1;
+        Address add1 = address_crossover_pair1.$1;
+        Address add2 = address_crossover_pair2.$1;
         return add1.offset - add2.offset;
       });
     }
 
     // convert to proper return type by dropping the offset
-    Map<int, BuiltList<Tuple2<Address, Crossover>>> builder = {
+    Map<int, BuiltList<(Address, Crossover)>> builder = {
       for (int idx in address_crossover_pairs.keys) idx: address_crossover_pairs[idx]!.toBuiltList(),
     };
 
@@ -1056,7 +1055,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
   /// into designs where helices do not have individual pitches and yaws.
   ///
   /// Pass these two maps into _groups_from_json so that groups can be assigned appropriate pitch, yaw values.
-  static Tuple3<Map<int, HelixBuilder>, Map<String, HelixPitchYaw>, Map<HelixPitchYaw, List<HelixBuilder>>>
+  static (Map<int, HelixBuilder>, Map<String, HelixPitchYaw>, Map<HelixPitchYaw, List<HelixBuilder>>)
   _helices_from_json(Map<String, dynamic> json_map, bool invert_y, Geometry geometry) {
     // Initialize containers
     List<HelixBuilder> helix_builders_list = [];
@@ -1156,7 +1155,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
       for (var helix_builder in helix_builders_list) helix_builder.idx!: helix_builder,
     };
 
-    return Tuple3(helix_builders_map, group_to_pitch_yaw, pitch_yaw_to_helices);
+    return (helix_builders_map, group_to_pitch_yaw, pitch_yaw_to_helices);
   }
 
   /// Returns map of helix group names to group as well as the grid.
@@ -1270,7 +1269,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
     return group_builders_map;
   }
 
-  static Tuple2<Map<int, HelixBuilder>, Map<String, HelixGroupBuilder>> _helices_and_groups_from_json(
+  static (Map<int, HelixBuilder>, Map<String, HelixGroupBuilder>) _helices_and_groups_from_json(
     Map<String, dynamic> json_map,
     bool invert_y,
     bool position_x_z_should_swap,
@@ -1285,10 +1284,12 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
     bool grid_is_none = grid == Grid.none;
     bool using_groups = json_map.containsKey(constants.groups_key);
 
-    var r = _helices_from_json(json_map, invert_y, geometry);
-    Map<int, HelixBuilder> helix_builders_map = r.item1;
-    Map<String, HelixPitchYaw> group_to_pitch_yaw = r.item2;
-    Map<HelixPitchYaw, List<HelixBuilder>> pitch_yaw_to_helices = r.item3;
+    // (Map<int, HelixBuilder>, Map<String, HelixPitchYaw>, Map<HelixPitchYaw, List<HelixBuilder>>)
+    var (
+      helix_builders_map,
+      group_to_pitch_yaw,
+      pitch_yaw_to_helices
+    ) = _helices_from_json(json_map, invert_y, geometry);
 
     Map<String, HelixGroupBuilder> group_builders_map = _groups_from_json(
       json_map,
@@ -1321,7 +1322,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
         group_builder.position.z = swap;
       }
     }
-    return Tuple2(helix_builders_map, group_builders_map);
+    return (helix_builders_map, group_builders_map);
   }
 
   static Design? from_json_str(String json_str, [bool invert_y = false]) {
@@ -1355,9 +1356,11 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
       legacy_keys: constants.legacy_geometry_keys,
     );
 
-    var t = Design._helices_and_groups_from_json(json_map, invert_y, position_x_z_should_swap, geometry);
-    var helix_builders_map = t.item1;
-    var group_builders_map = t.item2;
+    // (Map<int, HelixBuilder>, Map<String, HelixGroupBuilder>)
+    var (
+      helix_builders_map,
+      group_builders_map
+    ) = Design._helices_and_groups_from_json(json_map, invert_y, position_x_z_should_swap, geometry);
 
     // strands
     List<Strand> strands = [];
@@ -1377,12 +1380,11 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
     Map<String, ModificationInternal> mods_int = {};
 
     for (var all_mods_key_and_mods in [
-      Tuple2<String, Map<String, Modification5Prime>>(constants.design_modifications_5p_key, mods_5p),
-      Tuple2<String, Map<String, Modification3Prime>>(constants.design_modifications_3p_key, mods_3p),
-      Tuple2<String, Map<String, ModificationInternal>>(constants.design_modifications_int_key, mods_int),
+      (constants.design_modifications_5p_key, mods_5p),
+      (constants.design_modifications_3p_key, mods_3p),
+      (constants.design_modifications_int_key, mods_int),
     ]) {
-      var all_mods_key = all_mods_key_and_mods.item1;
-      var mods = all_mods_key_and_mods.item2;
+      var (all_mods_key, mods) = all_mods_key_and_mods; // (String, Map<String, Modification)
       if (json_map.keys.contains(all_mods_key)) {
         var all_mods_json = json_map[all_mods_key];
         for (var mod_key in all_mods_json.keys) {
@@ -1686,18 +1688,17 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
       if (domains.length == 0) continue;
 
       // check all consecutive domains on the same helix, sorted by start/end indices
-      List<Tuple3<int, bool, Domain>> offsets_data = [];
+      List<(int, bool, Domain)> offsets_data = [];
       for (var domain in domains) {
-        offsets_data.add(Tuple3<int, bool, Domain>(domain.start, true, domain));
-        offsets_data.add(Tuple3<int, bool, Domain>(domain.end, false, domain));
+        offsets_data.add((domain.start, true, domain));
+        offsets_data.add((domain.end, false, domain));
       }
-      offsets_data.sort((d1, d2) => d1.item1 - d2.item1);
+      offsets_data.sort((d1, d2) => d1.$1 - d2.$1);
 
       List<Domain> current_domains = [];
       for (var data in offsets_data) {
-        var offset = data.item1;
-        var is_start = data.item2;
-        var domain = data.item3;
+        var (offset, is_start, domain) = data; // (int, bool, Domain)
+
         if (is_start) {
           if (current_domains.length >= 2) {
             if (offset >= current_domains[1].end) {
@@ -2253,13 +2254,13 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
   /// either of them has unassigned DNA (either no DNA sequence, or a `?` wildcard).
   /// Otherwise we only consider them paired if they both have DNA; [allow_mismatches] then determines
   /// whether they need to be complementary to be considered a base pair.
-  BuiltMap<int, BuiltList<Tuple5<int, Domain, Domain, Strand, Strand>>> base_pairs_with_domain_strand(
+  BuiltMap<int, BuiltList<(int, Domain, Domain, Strand, Strand)>> base_pairs_with_domain_strand(
     bool allow_mismatches,
     bool allow_unassigned_dna,
     BuiltSet<Strand> selected_strands,
     bool include_base_pair_lines_if_other_strand_not_selected,
   ) {
-    var base_pairs_with_domain_strand = Map<int, BuiltList<Tuple5<int, Domain, Domain, Strand, Strand>>>();
+    var base_pairs_with_domain_strand = Map<int, BuiltList<(int, Domain, Domain, Strand, Strand)>>();
     BuiltSet<Domain> selected_domains =
         selected_strands
             .map((s) => s.substrands)
@@ -2268,11 +2269,9 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
             .map((x) => x as Domain)
             .toBuiltSet();
     for (int idx in this.helices.keys) {
-      List<Tuple5<int, Domain, Domain, Strand, Strand>> offsets_and_domain_strand = [];
-      List<Tuple2<Domain, Domain>> overlapping_domains = find_overlapping_domains_on_helix(idx);
-      for (var domain_pair in overlapping_domains) {
-        Domain dom1 = domain_pair.item1;
-        Domain dom2 = domain_pair.item2;
+      List<(int, Domain, Domain, Strand, Strand)> offsets_and_domain_strand = [];
+      List<(Domain, Domain)> overlapping_domains = find_overlapping_domains_on_helix(idx);
+      for (var (dom1, dom2) in overlapping_domains) { // (Domain, Domain)
         if (!allow_unassigned_dna && (dom1.dna_sequence == null || dom2.dna_sequence == null)) {
           // If not allowing unassigned DNA, then skip if either has no DNA sequence
           continue;
@@ -2292,9 +2291,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
         }
         // We already checked that these domains are overlapping by calling
         // `find_overlapping_domains_on_helix`, so the next call should not return null.
-        var start_and_end = dom1.compute_overlap(dom2)!;
-        int start = start_and_end.item1;
-        int end = start_and_end.item2;
+        var (start, end) = dom1.compute_overlap(dom2)!; // (int, int)
         for (int offset = start; offset < end; offset++) {
           if (dom1.deletions.contains(offset) || dom2.deletions.contains(offset)) {
             continue;
@@ -2316,7 +2313,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
                       base2 == constants.DNA_BASE_WILDCARD)) ||
               util.reverse_complementary(base1, base2, allow_wildcard: true)) {
             offsets_and_domain_strand.add(
-              Tuple5<int, Domain, Domain, Strand, Strand>(
+              (
                 offset,
                 dom1,
                 dom2,
@@ -2348,12 +2345,12 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
     );
     var base_pairs = Map<int, BuiltList<int>>();
     for (int idx in base_pairs_with_domain_strand.keys) {
-      base_pairs[idx] = base_pairs_with_domain_strand[idx]!.map((x) => x.item1).toList().build();
+      base_pairs[idx] = base_pairs_with_domain_strand[idx]!.map((x) => x.$1).toList().build();
     }
     return base_pairs.build();
   }
 
-  List<Tuple2<Domain, Domain>> find_overlapping_domains_on_helix(int helix_idx) {
+  List<(Domain, Domain)> find_overlapping_domains_on_helix(int helix_idx) {
     // compute list of pairs of domains that overlap on Helix `helix`
     List<Domain> forward_domains = domains_on_helix(helix_idx, forward: true);
     List<Domain> reverse_domains_list = domains_on_helix(helix_idx, forward: false);
@@ -2367,7 +2364,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
     // need to be efficient to remove the front element repeatedly
     var reverse_domains = Queue<Domain>.from(reverse_domains_list);
 
-    List<Tuple2<Domain, Domain>> overlapping_domains = [];
+    List<(Domain, Domain)> overlapping_domains = [];
 
     for (var forward_domain in forward_domains) {
       var reverse_domain = reverse_domains.first;
@@ -2390,7 +2387,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
 
       // add each reverse_domain that overlaps forward_domain
       while (forward_domain.overlaps(reverse_domain)) {
-        overlapping_domains.add(Tuple2<Domain, Domain>(forward_domain, reverse_domain));
+        overlapping_domains.add((forward_domain, reverse_domain));
 
         if (reverse_domain.end <= forward_domain.end) {
           // [-----f_dom--->[--next_f_dom-->
@@ -2466,7 +2463,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
     }
 
     // We do a DFS on strands
-    Map<String, Map<Tuple2<int, int>, bool>> seen = new HashMap();
+    Map<String, Map<(int, int), bool>> seen = new HashMap();
     seen['scaf'] = new HashMap();
     seen['stap'] = new HashMap();
     List<Strand> strands = [];
@@ -2479,9 +2476,9 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
     for (Map<String, dynamic> cadnano_helix in cadnano_v2_design['vstrands']) {
       int helix_num = cadnano_helix['num'];
       for (String strand_type in ['scaf', 'stap']) {
-        Map<Tuple2<int, int>, bool> seen_strand_type = seen[strand_type]!;
+        Map<(int, int), bool> seen_strand_type = seen[strand_type]!;
         for (int base_id = 0; base_id < num_bases; base_id++) {
-          if (seen_strand_type.containsKey(Tuple2(helix_num, base_id))) continue;
+          if (seen_strand_type.containsKey((helix_num, base_id))) continue;
           Strand? strand = Design._cadnano_v2_import_explore_strand(
             cadnano_helices,
             strand_type,
@@ -2507,11 +2504,11 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
   static Strand? _cadnano_v2_import_explore_strand(
     Map<int, Map<String, dynamic>> vstrands,
     String strand_type,
-    Map<Tuple2<int, int>, bool> seen,
+    Map<(int, int), bool> seen,
     int helix_num,
     int base_id,
   ) {
-    seen[Tuple2(helix_num, base_id)] = true;
+    seen[(helix_num, base_id)] = true;
     int id_from = vstrands[helix_num]![strand_type]![base_id]![0]!;
     int base_from = vstrands[helix_num]![strand_type]![base_id]![1]!;
     int id_to = vstrands[helix_num]![strand_type]![base_id]![2]!;
@@ -2519,7 +2516,12 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
 
     if (id_from == -1 && base_from == -1 && id_to == -1 && base_to == -1) return null;
 
-    Tuple3<int, int, bool> tmp = Design._cadnano_v2_import_find_5_end(
+    // (int, int, bool)
+    var (
+      strand_5_end_helix,
+      strand_5_end_base,
+      is_circular
+    ) = Design._cadnano_v2_import_find_5_end(
       vstrands,
       strand_type,
       helix_num,
@@ -2527,9 +2529,6 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
       id_from,
       base_from,
     );
-    int strand_5_end_helix = tmp.item1;
-    int strand_5_end_base = tmp.item2;
-    bool is_circular = tmp.item3;
 
     Color strand_color = Design._cadnano_v2_import_find_strand_color(
       vstrands,
@@ -2560,7 +2559,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
 
   // Routine which finds the 5' end of a strand in a cadnano v2 import. It returns the
   // helix and the base of the 5' end.
-  static Tuple3<int, int, bool> _cadnano_v2_import_find_5_end(
+  static (int, int, bool) _cadnano_v2_import_find_5_end(
     Map<int, Map<String, dynamic>> vstrands,
     String strand_type,
     int helix_num,
@@ -2571,21 +2570,21 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
     int id_from_before = helix_num; // 'id' stands for helix id
     int base_from_before = base_id;
 
-    Map<Tuple2<int, int>, bool> circular_seen = {};
+    Map<(int, int), bool> circular_seen = {};
     bool is_circular = false;
 
     while (!(id_from == -1 && base_from == -1)) {
-      if (circular_seen.containsKey(Tuple2(id_from, base_from))) {
+      if (circular_seen.containsKey((id_from, base_from))) {
         is_circular = true;
         break;
       }
-      circular_seen[Tuple2(id_from, base_from)] = true;
+      circular_seen[(id_from, base_from)] = true;
       id_from_before = id_from;
       base_from_before = base_from;
       id_from = vstrands[id_from_before]![strand_type]![base_from_before]![0]!;
       base_from = vstrands[id_from_before]![strand_type]![base_from_before]![1]!;
     }
-    return Tuple3(id_from_before, base_from_before, is_circular);
+    return (id_from_before, base_from_before, is_circular);
   }
 
   /// Routine that finds the color of a cadnano v2 strand."""
@@ -2622,7 +2621,7 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
   /// Finds all domains of a cadnano v2 strand.
   static List<Domain> _cadnano_v2_import_explore_domains(
     Map<int, Map<String, dynamic>> vstrands,
-    Map<Tuple2<int, int>, bool> seen,
+    Map<(int, int), bool> seen,
     String strand_type,
     int strand_5_end_base,
     int strand_5_end_helix,
@@ -2640,14 +2639,14 @@ abstract class Design with UnusedFields implements Built<Design, DesignBuilder>,
     else
       end = curr_base;
 
-    Map<Tuple2<int, int>, bool> circular_seen = {};
+    Map<(int, int), bool> circular_seen = {};
     while (!(curr_helix == -1 && curr_base == -1)) {
-      if (circular_seen.containsKey(Tuple2(curr_helix, curr_base))) break;
-      circular_seen[Tuple2(curr_helix, curr_base)] = true;
+      if (circular_seen.containsKey((curr_helix, curr_base))) break;
+      circular_seen[(curr_helix, curr_base)] = true;
 
       int old_helix = curr_helix;
       int old_base = curr_base;
-      seen[Tuple2(curr_helix, curr_base)] = true;
+      seen[(curr_helix, curr_base)] = true;
       curr_helix = vstrands[old_helix]![strand_type]![old_base]![2]!;
       curr_base = vstrands[old_helix]![strand_type]![old_base]![3]!;
       /* Add crossover
@@ -3011,10 +3010,9 @@ BuiltMap<int, BuiltList<Domain>> construct_helix_idx_to_domains_map(
 }
 
 _ensure_helix_idxs_unique(List<int> helix_indices, List<HelixBuilder> helix_builders_list) {
-  Tuple2<int, int>? repeated_idxs = util.repeated_element_indices(helix_indices);
+  (int, int)? repeated_idxs = util.repeated_element_indices(helix_indices);
   if (repeated_idxs != null) {
-    int i1 = repeated_idxs.item1;
-    int i2 = repeated_idxs.item2;
+    var (i1, i2) = repeated_idxs; // (int, int)
     int helix_idx = helix_builders_list[i1].idx!;
     throw IllegalDesignError(
       'helix idx values must be unique, '

--- a/lib/src/state/domain.dart
+++ b/lib/src/state/domain.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:color/color.dart';
-import 'package:tuple/tuple.dart';
 import 'package:built_collection/built_collection.dart';
 
 import 'select_mode.dart';
@@ -579,14 +578,14 @@ abstract class Domain
         this.compute_overlap(other) != null);
   }
 
-  Tuple2<int, int>? compute_overlap(Domain other) {
+  (int, int)? compute_overlap(Domain other) {
     int overlap_start = max(this.start, other.start);
     int overlap_end = min(this.end, other.end);
     if (overlap_start >= overlap_end) {
       // overlap is empty
       return null;
     }
-    return Tuple2<int, int>(overlap_start, overlap_end);
+    return (overlap_start, overlap_end);
   }
 
   bool contains_insertion_at(int offset) {

--- a/lib/src/state/export_dna_format.dart
+++ b/lib/src/state/export_dna_format.dart
@@ -6,7 +6,6 @@ import 'package:built_value/serializer.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:scadnano/src/view/menu_form_file.dart';
 import 'package:spreadsheet_decoder/spreadsheet_decoder.dart';
-import 'package:tuple/tuple.dart';
 
 import '../util.dart' as util;
 import 'strand.dart';
@@ -16,7 +15,7 @@ part 'export_dna_format.g.dart';
 
 typedef StrandComparison = int Function(Strand s1, Strand s2);
 
-Tuple2<int, int> strand_helix_offset_key(Strand strand, StrandOrder strand_order, bool column_major) {
+(int, int) strand_helix_offset_key(Strand strand, StrandOrder strand_order, bool column_major) {
   int helix_idx;
   int offset;
   if (strand_order == StrandOrder.five_prime) {
@@ -59,33 +58,29 @@ Tuple2<int, int> strand_helix_offset_key(Strand strand, StrandOrder strand_order
   } else {
     throw ArgumentError('${strand_order} is not a valid StrandOrder');
   }
-  return Tuple2<int, int>(helix_idx, offset);
+  return (helix_idx, offset);
 }
 
 /// Returns comparison function that can be used to sort Strands
 StrandComparison strands_comparison_function(StrandOrder strand_order, bool column_major) {
   int compare(Strand strand1, Strand strand2) {
-    var helix_offset1 = strand_helix_offset_key(strand1, strand_order, column_major);
-    var helix_offset2 = strand_helix_offset_key(strand2, strand_order, column_major);
-    int helix_idx1 = helix_offset1.item1;
-    int offset1 = helix_offset1.item2;
-    int helix_idx2 = helix_offset2.item1;
-    int offset2 = helix_offset2.item2;
+    var (helix_idx1, offset1) = strand_helix_offset_key(strand1, strand_order, column_major); // (int, int)
+    var (helix_idx2, offset2) = strand_helix_offset_key(strand2, strand_order, column_major); // (int, int)
 
-    var tuple1;
-    var tuple2;
+    (int, int) tuple1;
+    (int, int) tuple2;
     if (column_major) {
-      tuple1 = Tuple2<int, int>(offset1, helix_idx1);
-      tuple2 = Tuple2<int, int>(offset2, helix_idx2);
+      tuple1 = (offset1, helix_idx1);
+      tuple2 = (offset2, helix_idx2);
     } else {
-      tuple1 = Tuple2<int, int>(helix_idx1, offset1);
-      tuple2 = Tuple2<int, int>(helix_idx2, offset2);
+      tuple1 = (helix_idx1, offset1);
+      tuple2 = (helix_idx2, offset2);
     }
 
-    if (tuple1.item1 != tuple2.item1) {
-      return tuple1.item1 - tuple2.item1;
+    if (tuple1.$1 != tuple2.$1) {
+      return tuple1.$1 - tuple2.$1;
     } else {
-      return tuple1.item2 - tuple2.item2;
+      return tuple1.$2 - tuple2.$2;
     }
   }
 

--- a/lib/src/state/extension.dart
+++ b/lib/src/state/extension.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:color/color.dart';
-import 'package:tuple/tuple.dart';
 import 'package:built_collection/built_collection.dart';
 
 import 'select_mode.dart';

--- a/lib/src/state/helix.dart
+++ b/lib/src/state/helix.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:built_value/serializer.dart';
 import 'package:built_collection/built_collection.dart';
-import 'package:tuple/tuple.dart';
 import '../state/design.dart';
 import '../state/position3d.dart';
 import '../state/unused_fields.dart';
@@ -426,12 +425,12 @@ abstract class Helix with BuiltJsonSerializable, UnusedFields implements Built<H
     BuiltList<Address> crossover_addresses,
     Geometry geometry,
   ) {
-    List<Tuple2<double, double>> angles = [];
+    List<(double, double)> angles = [];
     for (var address in crossover_addresses) {
       var other_helix = helices[address.helix_idx]!;
       var angle_of_other_helix = util.angle_from_helix_to_helix(this, other_helix, geometry);
       var crossover_angle = this.backbone_angle_at_offset(address.offset, address.forward, geometry);
-      var relative_angle = Tuple2<double, double>(crossover_angle, angle_of_other_helix);
+      (double, double) relative_angle = (crossover_angle, angle_of_other_helix);
       angles.add(relative_angle);
     }
     var angle = util.minimum_strain_angle(angles);

--- a/lib/src/state/strand.dart
+++ b/lib/src/state/strand.dart
@@ -3,7 +3,6 @@ import 'package:color/color.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:react/react.dart';
-import 'package:tuple/tuple.dart';
 
 import 'address.dart';
 import 'helix.dart';
@@ -531,7 +530,7 @@ abstract class Strand
     for (var mod_idx in modifications_int.keys) {
       var mod = modifications_int[mod_idx]!;
       var ss_and_idx = _substrand_of_dna_idx(mod_idx);
-      Substrand ss = ss_and_idx.item1;
+      Substrand ss = ss_and_idx.$1;
       int ss_idx = index_of_substrand(ss);
       mods[ss_idx][mod_idx] = mod;
     }
@@ -563,9 +562,8 @@ abstract class Strand
 
     for (var mod_idx in modifications_int.keys) {
       var mod = modifications_int[mod_idx]!;
-      var ss_and_idx = _substrand_of_dna_idx(mod_idx);
-      Substrand ss = ss_and_idx.item1;
-      int idx_within_ss = ss_and_idx.item2;
+      var (ss, idx_within_ss) = _substrand_of_dna_idx(mod_idx);
+
       mods[ss]![idx_within_ss] = mod;
     }
 
@@ -576,7 +574,7 @@ abstract class Strand
     return mods_built.build();
   }
 
-  Tuple2<Substrand, int> _substrand_of_dna_idx(int dna_idx) {
+  (Substrand, int) _substrand_of_dna_idx(int dna_idx) {
     if (dna_idx < 0) {
       throw ArgumentError('dna_idx cannot be negative but is ${dna_idx}');
     }
@@ -590,7 +588,7 @@ abstract class Strand
     for (var ss in substrands) {
       int dna_idx_cur_ss_end = dna_idx_cur_ss_start + ss.dna_length();
       if (dna_idx_cur_ss_start <= dna_idx && dna_idx < dna_idx_cur_ss_end) {
-        return Tuple2<Substrand, int>(ss, dna_idx - dna_idx_cur_ss_start);
+        return (ss, dna_idx - dna_idx_cur_ss_start);
       }
       dna_idx_cur_ss_start = dna_idx_cur_ss_end;
     }
@@ -1074,11 +1072,11 @@ abstract class Strand
   /// If this and other are ligatable (they have a pair of 5'/3' ends adjacent)
   /// return the two [DNAEnd]s that can be ligated, in other (this.end, other.end),
   /// otherwise return null.
-  Tuple2<DNAEnd, DNAEnd>? ligatable_ends_with(Strand other) {
+  (DNAEnd, DNAEnd)? ligatable_ends_with(Strand other) {
     if (_ligatable_3p_to_5p_of(other)) {
-      return Tuple2<DNAEnd, DNAEnd>(dnaend_3p, other.dnaend_5p);
+      return (dnaend_3p, other.dnaend_5p);
     } else if (_ligatable_5p_to_3p_of(other)) {
-      return Tuple2<DNAEnd, DNAEnd>(dnaend_5p, other.dnaend_3p);
+      return (dnaend_5p, other.dnaend_3p);
     } else {
       return null;
     }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -31,7 +31,6 @@ import 'state/domains_move.dart';
 import 'state/group.dart';
 import 'state/strands_move.dart';
 import 'view/design.dart';
-import 'package:tuple/tuple.dart';
 import 'package:quiver/iterables.dart' as quiver;
 
 import 'app.dart';
@@ -406,14 +405,14 @@ Map<int, Helix> helices_list_to_map(List<Helix> helices) => {for (var helix in h
 dynamic unwrap_from_noindent(dynamic obj) => obj is NoIndent ? obj.value : obj;
 
 /// Finds two indices of elements in list that repeat, returning null if all elements are distinct.
-Tuple2<int, int>? repeated_element_indices<T>(List<T> list) {
+(int, int)? repeated_element_indices<T>(List<T> list) {
   Map<T, int> elt_to_idx = {};
   // should take time n log n; we don't do linear search for indices until we know which element repeats
   for (int i2 = 0; i2 < list.length; i2++) {
     T elt = list[i2];
     int? i1 = elt_to_idx[elt];
     if (i1 != null) {
-      return Tuple2<int, int>(i1, i2);
+      return (i1, i2);
     }
     elt_to_idx[elt] = i2;
   }
@@ -1942,7 +1941,7 @@ Point<double> compute_extension_free_end_svg(
   return ext_end_svg;
 }
 
-Tuple2<double, double> compute_extension_length_and_angle_from_point(
+(double, double) compute_extension_length_and_angle_from_point(
   Point<double> current_mouse_point,
   Point<double> attached_end_svg,
   Extension ext,
@@ -1963,7 +1962,7 @@ Tuple2<double, double> compute_extension_length_and_angle_from_point(
   if ((adjacent_domain.forward && ext.is_5p) || (!adjacent_domain.forward && !ext.is_5p)) {
     angle_radians = pi - angle_radians;
   }
-  return Tuple2(display_length, angle_radians * 180 / pi);
+  return (display_length, angle_radians * 180 / pi);
 }
 
 update_mouseover(SyntheticMouseEvent event_syn, Helix helix, Point<double> helix_svg_position) {
@@ -2103,8 +2102,8 @@ double angle_from_helix_to_helix(Helix helix, Helix other_helix, Geometry geomet
 //     angle :math:`\theta` by which to rotate all angles :math:`\theta_i`
 //     (but not changing any "zero angle" :math:`\mu_i`)
 //     such that :math:`\sum_i [(\theta + \theta_i) - \mu_i]^2` is minimized.
-double minimum_strain_angle(List<Tuple2<double, double>> relative_angles) {
-  var adjusted_angles = [for (var angle in relative_angles) angle.item1 - angle.item2];
+double minimum_strain_angle(List<(double, double)> relative_angles) {
+  var adjusted_angles = [for (var angle in relative_angles) angle.$1 - angle.$2];
   var ave_angle = average_angle(adjusted_angles);
   var min_strain_angle = -ave_angle;
   min_strain_angle %= 360;

--- a/lib/src/view/design_main_dna_sequence.dart
+++ b/lib/src/view/design_main_dna_sequence.dart
@@ -5,7 +5,6 @@ import 'package:built_collection/built_collection.dart';
 import 'package:platform_detect/platform_detect.dart';
 import 'package:scadnano/src/state/group.dart';
 import 'package:scadnano/src/view/transform_by_helix_group.dart';
-import 'package:tuple/tuple.dart';
 
 import '../state/helix.dart';
 import 'package:scadnano/src/state/geometry.dart';
@@ -177,9 +176,7 @@ class DesignMainDNASequenceComponent extends UiComponent2<DesignMainDNASequenceP
     var start_offset = '50%';
     var dy = '${0.1 * geometry.base_width_svg}';
 
-    Tuple2<double?, int> ls_fs = _calculate_letter_spacing_and_font_size_insertion(length);
-    double? letter_spacing = ls_fs.item1;
-    int font_size = ls_fs.item2;
+    var (letter_spacing, font_size) = _calculate_letter_spacing_and_font_size_insertion(length); // (double?, int)
 
     Map<String, dynamic> style_map;
     if (letter_spacing != null) {
@@ -216,14 +213,14 @@ class DesignMainDNASequenceComponent extends UiComponent2<DesignMainDNASequenceP
     var start_offset = '50%';
     var dy = '${0.1 * geometry.base_height_svg}';
 
-    Tuple2<double?, int> ls_fs;
+    (double?, int) ls_fs;
     if (util.is_hairpin(prev_domain, next_domain)) {
       ls_fs = _calculate_letter_spacing_and_font_size_hairpin(length);
     } else {
       ls_fs = _calculate_letter_spacing_and_font_size_loopout(length);
     }
-    double? letter_spacing = ls_fs.item1;
-    int font_size = ls_fs.item2;
+
+    var (letter_spacing, font_size) = ls_fs; // (double?, int)
 
     Map<String, dynamic> style_map;
     if (letter_spacing != null) {
@@ -255,9 +252,7 @@ class DesignMainDNASequenceComponent extends UiComponent2<DesignMainDNASequenceP
     var start_offset = '50%';
     var dy = '${0.1 * geometry.base_height_svg}';
 
-    Tuple2<double, int> ls_fs = _calculate_letter_spacing_and_font_size_extension(ext);
-    double letter_spacing = ls_fs.item1;
-    int font_size = ls_fs.item2;
+    var (letter_spacing, font_size) = _calculate_letter_spacing_and_font_size_extension(ext); // (double, int)
 
     Map<String, dynamic> style_map = {'letterSpacing': '${letter_spacing}em', 'fontSize': '${font_size}px'};
 
@@ -275,19 +270,19 @@ class DesignMainDNASequenceComponent extends UiComponent2<DesignMainDNASequenceP
   }
 }
 
-Tuple2<double, int> _calculate_letter_spacing_and_font_size_loopout(int len) {
+(double, int) _calculate_letter_spacing_and_font_size_loopout(int len) {
   double letter_spacing = 0;
   int font_size = 12;
-  return Tuple2<double, int>(letter_spacing, font_size);
+  return (letter_spacing, font_size);
 }
 
-Tuple2<double, int> _calculate_letter_spacing_and_font_size_extension(Extension ext) {
+(double, int) _calculate_letter_spacing_and_font_size_extension(Extension ext) {
   double letter_spacing = 0;
   int font_size = 12;
-  return Tuple2<double, int>(letter_spacing, font_size);
+  return (letter_spacing, font_size);
 }
 
-Tuple2<double?, int> _calculate_letter_spacing_and_font_size_hairpin(int len) {
+(double?, int) _calculate_letter_spacing_and_font_size_hairpin(int len) {
   double? letter_spacing;
   int font_size = max(6, 12 - max(0, len - 6));
   if (browser.isChrome) {
@@ -315,10 +310,10 @@ Tuple2<double?, int> _calculate_letter_spacing_and_font_size_hairpin(int len) {
     }
     letter_spacing = null;
   }
-  return Tuple2<double?, int>(letter_spacing, font_size);
+  return (letter_spacing, font_size);
 }
 
-Tuple2<double?, int> _calculate_letter_spacing_and_font_size_insertion(int num_insertions) {
+(double?, int) _calculate_letter_spacing_and_font_size_insertion(int num_insertions) {
   // UGGG
   double? letter_spacing;
   int font_size = max(6, 12 - (num_insertions - 1));
@@ -347,7 +342,7 @@ Tuple2<double?, int> _calculate_letter_spacing_and_font_size_insertion(int num_i
     }
     letter_spacing = null;
   }
-  return Tuple2<double?, int>(letter_spacing, font_size);
+  return (letter_spacing, font_size);
 }
 
 // keep this around in case this is how we want to export to an SVG file and it doesn't do textLength well

--- a/lib/src/view/design_main_dna_sequence.dart
+++ b/lib/src/view/design_main_dna_sequence.dart
@@ -176,7 +176,9 @@ class DesignMainDNASequenceComponent extends UiComponent2<DesignMainDNASequenceP
     var start_offset = '50%';
     var dy = '${0.1 * geometry.base_width_svg}';
 
-    var (letter_spacing, font_size) = _calculate_letter_spacing_and_font_size_insertion(length); // (double?, int)
+    var (letter_spacing, font_size) = _calculate_letter_spacing_and_font_size_insertion(
+      length,
+    ); // (double?, int)
 
     Map<String, dynamic> style_map;
     if (letter_spacing != null) {

--- a/lib/src/view/design_main_domain_name_mismatches.dart
+++ b/lib/src/view/design_main_domain_name_mismatches.dart
@@ -2,7 +2,6 @@ import 'dart:html';
 
 import 'package:over_react/over_react.dart';
 import 'package:built_collection/built_collection.dart';
-import 'package:tuple/tuple.dart';
 
 import '../state/domain_name_mismatch.dart';
 import '../state/design.dart';
@@ -44,11 +43,11 @@ class DesignMainDomainNameMismatchesComponent extends UiComponent2<DesignMainDom
       for (var domain_name_mismatch in domain_name_mismatches) {
         Domain forward_domain = domain_name_mismatch.forward_domain;
         Domain reverse_domain = domain_name_mismatch.reverse_domain;
-        Tuple2<int, int>? overlap = forward_domain.compute_overlap(reverse_domain);
+        (int, int)? overlap = forward_domain.compute_overlap(reverse_domain);
         if (overlap == null) throw AssertionError('overlap should not be null');
 
         // draw mismatch stars at midpoint of overlap of domains
-        int mid = (overlap.item1 + overlap.item2) ~/ 2;
+        int mid = (overlap.$1 + overlap.$2) ~/ 2;
         for (Domain domain in [forward_domain, reverse_domain]) {
           var helix = props.design.helices[domain.helix]!;
           var group = props.design.groups[helix.group]!;

--- a/lib/src/view/design_main_strand_dna_extension_end_moving.dart
+++ b/lib/src/view/design_main_strand_dna_extension_end_moving.dart
@@ -101,7 +101,7 @@ class ExtensionEndMovingComponent extends UiComponent2<ExtensionEndMovingProps> 
       props.ext!.adjacent_domain,
       props.geometry!,
     );
-    var rotation_degrees = util.compute_end_rotation(display_angle.item2, props.forward!, props.is_5p!);
+    var rotation_degrees = util.compute_end_rotation(display_angle.$2, props.forward!, props.is_5p!);
     // https://stackoverflow.com/questions/15138801/rotate-rectangle-around-its-own-center-in-svg
     end_props = end_props..transform = "rotate($rotation_degrees)";
     return end_props();

--- a/lib/src/view/design_main_strand_insertion.dart
+++ b/lib/src/view/design_main_strand_insertion.dart
@@ -7,7 +7,6 @@ import 'package:platform_detect/platform_detect.dart';
 import 'package:scadnano/src/state/context_menu.dart';
 import 'package:scadnano/src/state/dialog.dart';
 import 'package:scadnano/src/state/geometry.dart';
-import 'package:tuple/tuple.dart';
 
 import '../state/selectable.dart';
 import '../state/helix.dart';
@@ -21,7 +20,7 @@ import 'design_main_strand_loopout.dart';
 
 part 'design_main_strand_insertion.over_react.g.dart';
 
-typedef Tuple2<Insertion, Domain> PairedInsertionFinder(Insertion insertion, Domain substrand);
+typedef (Insertion, Domain) PairedInsertionFinder(Insertion insertion, Domain substrand);
 
 UiFactory<DesignMainStrandInsertionProps> DesignMainStrandInsertion = _$DesignMainStrandInsertion;
 

--- a/lib/src/view/design_main_warning_star.dart
+++ b/lib/src/view/design_main_warning_star.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:over_react/over_react.dart';
 import 'package:scadnano/src/state/geometry.dart';
-import 'package:tuple/tuple.dart';
 
 part 'design_main_warning_star.over_react.g.dart';
 
@@ -18,8 +17,8 @@ mixin DesignMainWarningStarProps on UiProps {
 class DesignMainWarningStarComponent extends UiComponent2<DesignMainWarningStarProps> {
   @override
   render() {
-    List<double> xs = List<double>.from(_star_at_origin().item1);
-    List<double> ys = List<double>.from(_star_at_origin().item2);
+    List<double> xs = List<double>.from(_star_at_origin().$1);
+    List<double> ys = List<double>.from(_star_at_origin().$2);
 
     num rotate_degrees = 0;
     if (!props.forward) {
@@ -46,7 +45,7 @@ class DesignMainWarningStarComponent extends UiComponent2<DesignMainWarningStarP
       ..transform = 'rotate(${rotate_degrees} ${props.base_svg_pos.x} ${props.base_svg_pos.y})')();
   }
 
-  Tuple2<List<double>, List<double>> _star_at_origin() {
+  (List<double>, List<double>) _star_at_origin() {
     // assume bottom points of star are at origin
     List<double> xs = [];
     List<double> ys = [];
@@ -69,6 +68,6 @@ class DesignMainWarningStarComponent extends UiComponent2<DesignMainWarningStarP
       inner_angle += 2 * pi / num_points;
       outer_angle += 2 * pi / num_points;
     }
-    return Tuple2<List<double>, List<double>>(xs, ys);
+    return (xs, ys);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -34,26 +34,26 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   bazel_worker:
     dependency: transitive
     description:
       name: bazel_worker
-      sha256: "57035594b87d9f5af99f1a80e1edf5411dadbdf5acfc4f90403e3849f57dd0f0"
+      sha256: "373a6ef07caa6c674c1cf144a5fe1e0f712c040552031ce669f298e35f7e110a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   boolean_selector:
     dependency: transitive
     description:
@@ -66,74 +66,74 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
+      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "79b2aef6ac2ed00046867ed354c88778c9c0f029df8a20fe10b5436826721ef9"
+      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.0.4"
   build_modules:
     dependency: transitive
     description:
       name: build_modules
-      sha256: "349f492c6cf66d32d24b71368908df23426440bf9ee4642fdb79978adb82a877"
+      sha256: b1fc29a603669b25a5d95cc9610ed649e9f00e6075e5b6b721aa1a095cff13de
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.12"
+    version: "5.0.13"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "028819cfb90051c6b5440c7e574d1896f8037e3c96cf17aaeb054c9311cfbf4d"
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.13"
+    version: "2.4.15"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0
+      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.2"
+    version: "8.0.0"
   build_test:
     dependency: "direct dev"
     description:
       name: build_test
-      sha256: "260dbba934f41b0a42935e9cae1f5731b94f0c3e489dc97bcf8e281265aaa5ae"
+      sha256: a580c76c28440d0006b75c6746bbbb3c1648959ba9e1afae2c2b0f2c26acdf3d
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.3"
   build_web_compilers:
     dependency: "direct dev"
     description:
       name: build_web_compilers
-      sha256: cbe4deca108e5a9949df0065e7ef3777f54d8545b9232f2d8ef74601f2fb2df3
+      sha256: f9b8e84dbfa7688221c2376e6f68ffd796597785a0a5b1e8cd2516a92fdc0a3c
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.3"
+    version: "4.1.5"
   built_collection:
     dependency: "direct main"
     description:
@@ -146,18 +146,18 @@ packages:
     dependency: "direct main"
     description:
       name: built_value
-      sha256: "28a712df2576b63c6c005c465989a348604960c0958d28be5303ba9baa841ac2"
+      sha256: ea90e81dc4a25a043d9bee692d20ed6d1c4a1662a28c03a96417446c093ed6b4
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.3"
+    version: "8.9.5"
   built_value_generator:
     dependency: "direct dev"
     description:
       name: built_value_generator
-      sha256: bb06c5e9dbdbd35ed6de21520e2e5112582c964fa584e2a4bb59887fc7a169b0
+      sha256: be8640bd52d67a5e6747379778b81ca2e6a40f61df475f81beb72fde62e32524
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.2"
+    version: "8.9.5"
   checked_yaml:
     dependency: transitive
     description:
@@ -166,6 +166,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   clock:
     dependency: transitive
     description:
@@ -210,10 +218,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: e3493833ea012784c740e341952298f1cc77f1f01b1bbc3eb4eecf6984fb7f43
+      sha256: "802bd084fb82e55df091ec8ad1553a7331b61c08251eef19a508b6f3f3a9858d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.13.1"
   crypto:
     dependency: transitive
     description:
@@ -234,10 +242,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "7856d364b589d1f08986e140938578ed36ed948581fbc3bc9aef1805039ac5ab"
+      sha256: "7306ab8a2359a48d22310ad823521d723acfed60ee1f7e37388e8986853b6820"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.7"
+    version: "2.3.8"
   dialog:
     dependency: "direct main"
     description:
@@ -282,10 +290,10 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   graphs:
     dependency: transitive
     description:
@@ -298,18 +306,18 @@ packages:
     dependency: transitive
     description:
       name: html
-      sha256: "1fc58edeaec4307368c60d59b7e15b9d658b57d7f3125098b6294153c75337ec"
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
       url: "https://pub.dev"
     source: hosted
-    version: "0.15.5"
+    version: "0.15.6"
   http:
     dependency: "direct main"
     description:
       name: http
-      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
+      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.4.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -394,10 +402,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -418,26 +426,26 @@ packages:
     dependency: "direct main"
     description:
       name: over_react
-      sha256: "9052c0c979811bd7ff35a145bd79de0da6f6f107017909826ed24fc9ee83b990"
+      sha256: cc478423217914a7e412dc6d8a71df804341b5af2db8718e16e7f6cd39ed912d
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.1"
+    version: "5.4.4"
   over_react_test:
     dependency: "direct dev"
     description:
       name: over_react_test
-      sha256: "4b88ea0db06a2ad7d331cf2d1c68fdd531eee6273f3f61b47d4f16c973d6eb57"
+      sha256: "1469bf980b3e917ef2e64936d491fdf52e375710ed495918970446040da77e50"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      sha256: "92d4488434b520a62570293fbd33bb556c7d49230791c1b4bbd973baf6d2dc67"
+      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.0"
   path:
     dependency: "direct main"
     description:
@@ -450,10 +458,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
+      sha256: "07c8f0b1913bcde1ff0d26e57ace2f3012ccbf2b204e070290dad3bb22797646"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "6.1.0"
   platform_detect:
     dependency: "direct main"
     description:
@@ -474,26 +482,26 @@ packages:
     dependency: transitive
     description:
       name: protobuf
-      sha256: "68645b24e0716782e58948f8467fd42a880f255096a821f9e7d0ec625b00c84d"
+      sha256: fbb0c37d435641d0b84813c1dad41e6fa61ddc880a320bce16b3063ecec35aa6
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.2.0"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: "81876843eb50dc2e1e5b151792c9a985c5ed2536914115ed04e9c8528f6647b0"
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   quiver:
     dependency: "direct main"
     description:
@@ -506,10 +514,10 @@ packages:
     dependency: "direct main"
     description:
       name: react
-      sha256: cebcf69d0366f72552672a0a034a75277b67711b4f1c2c71cd1d8d134fadf8c5
+      sha256: "85f92902849961083e22fa17c5916da3ca9dbb84481c87cded301b8e96812eda"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "7.3.0"
   redux:
     dependency: "direct main"
     description:
@@ -570,18 +578,18 @@ packages:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   source_gen:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
+      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "2.0.0"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -626,10 +634,10 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "4ac0537115a24d772c408a2520ecd0abb99bca2ea9c4e634ccbdbfae64fe17ec"
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
@@ -658,34 +666,34 @@ packages:
     dependency: "direct main"
     description:
       name: test
-      sha256: "8391fbe68d520daf2314121764d38e37f934c02fd7301ad18307bd93bd6b725d"
+      sha256: f1665eeffe3b6b193548b5f515e8d1b54ccd9a6e0e7721a417e134e7ed7f06a1
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.14"
+    version: "1.26.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "6c7653816b1c938e121b69ff63a33c9dc68102b65a5fb0a5c0f9786256ed33e6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.5"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
+      sha256: "3caa7c3956b366643b2dedecff764cc32030317b2a15252aed845570df6bcc0f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.8"
+    version: "0.6.9"
   test_html_builder:
     dependency: "direct dev"
     description:
       name: test_html_builder
-      sha256: f5ff610bd16608eb046543e315b33cfe07ce339388b6e07258772e52a800d941
+      sha256: "0d7a60f43ca39ce73bb05505820d42026ed93fe476aeac2cc398ce30e00890ed"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.12"
   timing:
     dependency: transitive
     description:
@@ -746,26 +754,26 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   web_socket:
     dependency: transitive
     description:
       name: web_socket
-      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.6"
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "9f187088ed104edd8662ca07af4b124465893caf063ba29758f97af57e61da8f"
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.3"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -791,4 +799,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.0 <3.8.0-z"
+  dart: ">=3.7.0 <3.9.0-z"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -702,14 +702,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.22"
-  tuple:
-    dependency: "direct main"
-    description:
-      name: tuple
-      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,6 @@ dependencies:
   over_react: ^5.3.0
   spreadsheet_decoder: ^2.2.0
   test: ^1.25.8
-  tuple: ^2.0.2
   xml: ^6.3.0
   watcher: ^1.1.0
 

--- a/test/base_pairs_test.dart
+++ b/test/base_pairs_test.dart
@@ -1,7 +1,5 @@
 import 'dart:convert';
 
-import 'package:tuple/tuple.dart';
-
 import 'package:scadnano/src/actions/actions.dart';
 import 'package:scadnano/src/json_serializable.dart';
 import 'package:scadnano/src/reducers/app_state_reducer.dart';
@@ -87,7 +85,7 @@ main() {
       var overlapping_domains_h0 = test_design.find_overlapping_domains_on_helix(0);
 
       expect(overlapping_domains_h0.length, 1);
-      expect(overlapping_domains_h0, contains(Tuple2<Domain, Domain>(d01f, d01r)));
+      expect(overlapping_domains_h0, contains((d01f, d01r)));
     });
     test('find_overlapping_domains', () {
       var d01f = design.strands[0].domains[0];
@@ -115,14 +113,14 @@ main() {
       expect(overlapping_domains_h0.length, 4);
       expect(overlapping_domains_h1.length, 3);
 
-      expect(overlapping_domains_h0, contains(Tuple2<Domain, Domain>(d01f, d01r)));
-      expect(overlapping_domains_h0, contains(Tuple2<Domain, Domain>(d02f, d02r)));
-      expect(overlapping_domains_h0, contains(Tuple2<Domain, Domain>(d03f, d02r)));
-      expect(overlapping_domains_h0, contains(Tuple2<Domain, Domain>(d05f, d04r)));
+      expect(overlapping_domains_h0, contains((d01f, d01r)));
+      expect(overlapping_domains_h0, contains((d02f, d02r)));
+      expect(overlapping_domains_h0, contains((d03f, d02r)));
+      expect(overlapping_domains_h0, contains((d05f, d04r)));
 
-      expect(overlapping_domains_h1, contains(Tuple2<Domain, Domain>(d11f, d11r)));
-      expect(overlapping_domains_h1, contains(Tuple2<Domain, Domain>(d11f, d12r)));
-      expect(overlapping_domains_h1, contains(Tuple2<Domain, Domain>(d12f, d12r)));
+      expect(overlapping_domains_h1, contains((d11f, d11r)));
+      expect(overlapping_domains_h1, contains((d11f, d12r)));
+      expect(overlapping_domains_h1, contains((d12f, d12r)));
     });
 
     test('design_base_pairs_mismatches', () {

--- a/test/helix_relax_rolls_test.dart
+++ b/test/helix_relax_rolls_test.dart
@@ -638,66 +638,42 @@ main() {
     });
 
     test('minimum_strain_angle_0_10_20_relative_to_0', () {
-      List<(double, double)> relative_angles = [
-        (0, 0),
-        (10, 0),
-        (20, 0),
-      ];
+      List<(double, double)> relative_angles = [(0, 0), (10, 0), (20, 0)];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 350.0;
       expect(act_min_strain_angle, closeTo(exp_min_strain_angle, epsilon));
     });
 
     test('minimum_strain_angle_0_10_50_relative_to_0', () {
-      List<(double, double)> relative_angles = [
-        (0, 0),
-        (10, 0),
-        (50, 0),
-      ];
+      List<(double, double)> relative_angles = [(0, 0), (10, 0), (50, 0)];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 340.0;
       expect(act_min_strain_angle, closeTo(exp_min_strain_angle, epsilon));
     });
 
     test('minimum_strain_angle_0_10_80_relative_to_0', () {
-      List<(double, double)> relative_angles = [
-        (0, 0),
-        (10, 0),
-        (80, 0),
-      ];
+      List<(double, double)> relative_angles = [(0, 0), (10, 0), (80, 0)];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 330.0;
       expect(act_min_strain_angle, closeTo(exp_min_strain_angle, epsilon));
     });
 
     test('minimum_strain_angle_350_0_10_relative_to_0', () {
-      List<(double, double)> relative_angles = [
-        (350, 0),
-        (0, 0),
-        (10, 0),
-      ];
+      List<(double, double)> relative_angles = [(350, 0), (0, 0), (10, 0)];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 0.0;
       expect(act_min_strain_angle, closeTo(exp_min_strain_angle, epsilon));
     });
 
     test('minimum_strain_angle_350_0_40_relative_to_0', () {
-      List<(double, double)> relative_angles = [
-        (350, 0),
-        (0, 0),
-        (40, 0),
-      ];
+      List<(double, double)> relative_angles = [(350, 0), (0, 0), (40, 0)];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 350.0;
       expect(act_min_strain_angle, closeTo(exp_min_strain_angle, epsilon));
     });
 
     test('minimum_strain_angle_350_10_60_relative_to_0', () {
-      List<(double, double)> relative_angles = [
-        (350, 0),
-        (10, 0),
-        (60, 0),
-      ];
+      List<(double, double)> relative_angles = [(350, 0), (10, 0), (60, 0)];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 340.0;
       expect(act_min_strain_angle, closeTo(exp_min_strain_angle, epsilon));
@@ -735,11 +711,7 @@ main() {
     });
 
     test('minimum_strain_angle_174_179_184_relative_to_0', () {
-      List<(double, double)> relative_angles = [
-        (174, 0),
-        (179, 0),
-        (184, 0),
-      ];
+      List<(double, double)> relative_angles = [(174, 0), (179, 0), (184, 0)];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 181.0;
       expect(act_min_strain_angle, closeTo(exp_min_strain_angle, epsilon));

--- a/test/helix_relax_rolls_test.dart
+++ b/test/helix_relax_rolls_test.dart
@@ -17,7 +17,6 @@ import 'package:test/test.dart';
 
 import 'package:scadnano/src/state/design.dart';
 import 'package:scadnano/src/actions/actions.dart' as actions;
-import 'package:tuple/tuple.dart';
 
 import 'package:scadnano/src/util.dart' as util;
 import 'package:scadnano/src/constants.dart' as constants;
@@ -639,10 +638,10 @@ main() {
     });
 
     test('minimum_strain_angle_0_10_20_relative_to_0', () {
-      var relative_angles = [
-        Tuple2<double, double>(0, 0),
-        Tuple2<double, double>(10, 0),
-        Tuple2<double, double>(20, 0),
+      List<(double, double)> relative_angles = [
+        (0, 0),
+        (10, 0),
+        (20, 0),
       ];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 350.0;
@@ -650,10 +649,10 @@ main() {
     });
 
     test('minimum_strain_angle_0_10_50_relative_to_0', () {
-      var relative_angles = [
-        Tuple2<double, double>(0, 0),
-        Tuple2<double, double>(10, 0),
-        Tuple2<double, double>(50, 0),
+      List<(double, double)> relative_angles = [
+        (0, 0),
+        (10, 0),
+        (50, 0),
       ];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 340.0;
@@ -661,10 +660,10 @@ main() {
     });
 
     test('minimum_strain_angle_0_10_80_relative_to_0', () {
-      var relative_angles = [
-        Tuple2<double, double>(0, 0),
-        Tuple2<double, double>(10, 0),
-        Tuple2<double, double>(80, 0),
+      List<(double, double)> relative_angles = [
+        (0, 0),
+        (10, 0),
+        (80, 0),
       ];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 330.0;
@@ -672,10 +671,10 @@ main() {
     });
 
     test('minimum_strain_angle_350_0_10_relative_to_0', () {
-      var relative_angles = [
-        Tuple2<double, double>(350, 0),
-        Tuple2<double, double>(0, 0),
-        Tuple2<double, double>(10, 0),
+      List<(double, double)> relative_angles = [
+        (350, 0),
+        (0, 0),
+        (10, 0),
       ];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 0.0;
@@ -683,10 +682,10 @@ main() {
     });
 
     test('minimum_strain_angle_350_0_40_relative_to_0', () {
-      var relative_angles = [
-        Tuple2<double, double>(350, 0),
-        Tuple2<double, double>(0, 0),
-        Tuple2<double, double>(40, 0),
+      List<(double, double)> relative_angles = [
+        (350, 0),
+        (0, 0),
+        (40, 0),
       ];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 350.0;
@@ -694,10 +693,10 @@ main() {
     });
 
     test('minimum_strain_angle_350_10_60_relative_to_0', () {
-      var relative_angles = [
-        Tuple2<double, double>(350, 0),
-        Tuple2<double, double>(10, 0),
-        Tuple2<double, double>(60, 0),
+      List<(double, double)> relative_angles = [
+        (350, 0),
+        (10, 0),
+        (60, 0),
       ];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 340.0;
@@ -705,14 +704,14 @@ main() {
     });
 
     test('minimum_strain_angle_350_10_60_relative_to_0_and_20_0_310_relative_to_10', () {
-      var relative_angles = [
-        Tuple2<double, double>(350, 0), // -10
-        Tuple2<double, double>(10, 0), // 10
-        Tuple2<double, double>(60, 0), // 60
+      List<(double, double)> relative_angles = [
+        (350, 0), // -10
+        (10, 0), // 10
+        (60, 0), // 60
         ///////////////////////////////// ave to 20
-        Tuple2<double, double>(20, 10), // 10
-        Tuple2<double, double>(0, 10), // -10
-        Tuple2<double, double>(340, 10), // -30
+        (20, 10), // 10
+        (0, 10), // -10
+        (340, 10), // -30
         ///////////////////////////////// ave to -10
         ///////////////////////////////// total average is (20-10)/2 = 5, so 355 (-5) to correct it
       ];
@@ -722,24 +721,24 @@ main() {
     });
 
     test('minimum_strain_angle_179_181_relative_to_0', () {
-      var relative_angles = [Tuple2<double, double>(179, 0), Tuple2<double, double>(181, 0)];
+      List<(double, double)> relative_angles = [(179, 0), (181, 0)];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 180.0;
       expect(act_min_strain_angle, closeTo(exp_min_strain_angle, epsilon));
     });
 
     test('minimum_strain_angle_181_183_relative_to_0', () {
-      var relative_angles = [Tuple2<double, double>(181, 0), Tuple2<double, double>(183, 0)];
+      List<(double, double)> relative_angles = [(181, 0), (183, 0)];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 178.0;
       expect(act_min_strain_angle, closeTo(exp_min_strain_angle, epsilon));
     });
 
     test('minimum_strain_angle_174_179_184_relative_to_0', () {
-      var relative_angles = [
-        Tuple2<double, double>(174, 0),
-        Tuple2<double, double>(179, 0),
-        Tuple2<double, double>(184, 0),
+      List<(double, double)> relative_angles = [
+        (174, 0),
+        (179, 0),
+        (184, 0),
       ];
       var act_min_strain_angle = util.minimum_strain_angle(relative_angles);
       var exp_min_strain_angle = 181.0;

--- a/test/oxdna_export_test.dart
+++ b/test/oxdna_export_test.dart
@@ -4,7 +4,6 @@ import 'package:scadnano/src/state/grid_position.dart';
 import 'package:scadnano/src/state/group.dart';
 import 'package:scadnano/src/state/position3d.dart';
 import 'package:test/test.dart';
-import 'package:tuple/tuple.dart';
 
 import 'package:scadnano/src/middleware/oxdna_export.dart';
 import 'package:scadnano/src/state/helix.dart';
@@ -60,9 +59,9 @@ main() {
       int expected_num_nucleotides = 7 * 4;
       int expected_strand_length = 7 * 2;
 
-      Tuple2<String, String> oxdna_dat_top = to_oxdna_format(design);
-      List<String> dat_lines = oxdna_dat_top.item1.trim().split('\n');
-      List<String> top_lines = oxdna_dat_top.item2.trim().split('\n');
+      (String, String) oxdna_dat_top = to_oxdna_format(design);
+      List<String> dat_lines = oxdna_dat_top.$1.trim().split('\n');
+      List<String> top_lines = oxdna_dat_top.$2.trim().split('\n');
 
       // check length of output files are as expected (matches # of nucleotides plus header size)
       expect(dat_lines.length, expected_num_nucleotides + 3);
@@ -220,9 +219,9 @@ main() {
       int expected_num_nucleotides = 7 * 4;
       int expected_strand_length = 7 * 2;
 
-      Tuple2<String, String> oxdna_dat_top = to_oxdna_format(design);
-      List<String> dat_lines = oxdna_dat_top.item1.trim().split('\n');
-      List<String> top_lines = oxdna_dat_top.item2.trim().split('\n');
+      (String, String) oxdna_dat_top = to_oxdna_format(design);
+      List<String> dat_lines = oxdna_dat_top.$1.trim().split('\n');
+      List<String> top_lines = oxdna_dat_top.$2.trim().split('\n');
 
       // check length of output files are as expected (matches # of nucleotides plus header size)
       expect(dat_lines.length, expected_num_nucleotides + 3);
@@ -369,9 +368,9 @@ main() {
       int expected_num_nucleotides = 8 * 3;
       int expected_strand_length = 8 * 3;
 
-      Tuple2<String, String> oxdna_dat_top = to_oxdna_format(design);
-      List<String> dat_lines = oxdna_dat_top.item1.trim().split('\n');
-      List<String> top_lines = oxdna_dat_top.item2.trim().split('\n');
+      (String, String) oxdna_dat_top = to_oxdna_format(design);
+      List<String> dat_lines = oxdna_dat_top.$1.trim().split('\n');
+      List<String> top_lines = oxdna_dat_top.$2.trim().split('\n');
 
       // check length of output files are as expected (matches # of nucleotides plus header size)
       expect(dat_lines.length, expected_num_nucleotides + 3);
@@ -474,9 +473,9 @@ main() {
       int expected_num_nucleotides = 6;
       int expected_strand_length = 6;
 
-      Tuple2<String, String> oxdna_dat_top = to_oxdna_format(design);
-      List<String> dat_lines = oxdna_dat_top.item1.trim().split('\n');
-      List<String> top_lines = oxdna_dat_top.item2.trim().split('\n');
+      (String, String) oxdna_dat_top = to_oxdna_format(design);
+      List<String> dat_lines = oxdna_dat_top.$1.trim().split('\n');
+      List<String> top_lines = oxdna_dat_top.$2.trim().split('\n');
 
       // check length of output files are as expected (matches # of nucleotides plus header size)
       expect(dat_lines.length, expected_num_nucleotides + 3);
@@ -577,9 +576,9 @@ main() {
       int expected_num_nucleotides = 8;
       int expected_strand_length = 8;
 
-      Tuple2<String, String> oxdna_dat_top = to_oxdna_format(design);
-      List<String> dat_lines = oxdna_dat_top.item1.trim().split('\n');
-      List<String> top_lines = oxdna_dat_top.item2.trim().split('\n');
+      (String, String) oxdna_dat_top = to_oxdna_format(design);
+      List<String> dat_lines = oxdna_dat_top.$1.trim().split('\n');
+      List<String> top_lines = oxdna_dat_top.$2.trim().split('\n');
 
       // check length of output files are as expected (matches # of nucleotides plus header size)
       expect(dat_lines.length, expected_num_nucleotides + 3);
@@ -683,9 +682,9 @@ main() {
       int expected_strand_1_length = 7 + 4;
       int expected_strand_2_length = 7;
 
-      Tuple2<String, String> oxdna_dat_top = to_oxdna_format(design);
-      List<String> dat_lines = oxdna_dat_top.item1.trim().split('\n');
-      List<String> top_lines = oxdna_dat_top.item2.trim().split('\n');
+      (String, String) oxdna_dat_top = to_oxdna_format(design);
+      List<String> dat_lines = oxdna_dat_top.$1.trim().split('\n');
+      List<String> top_lines = oxdna_dat_top.$2.trim().split('\n');
 
       // check length of output files are as expected (matches # of nucleotides plus header size)
       expect(dat_lines.length, expected_num_nucleotides + 3);


### PR DESCRIPTION
## Description
This replaces all instances of `TupleX` with Dart's records.

## Related Issue
This fixes #984.

## Motivation and Context
This is much cleaner than using the `Tuple` library, and it was requested by #984.

## How Has This Been Tested?
This was tested using the already existing unit tests. Although, some of the unit tests were modified to accommodate this change.

## Screenshots (if appropriate):
N/A