### PR TITLE
1034 make warning about unassigned dna optional when oxview view is open and prevent when closed

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,10 @@
       "Bash(grep:*)",
       "Bash(dart pub:*)",
       "Bash(dart analyze:*)",
-      "Bash(dart format:*)"
+      "Bash(dart format:*)",
+      "WebFetch(domain:github.com)",
+      "Bash(dart run build_runner build:*)",
+      "Bash(python:*)"
     ],
     "deny": [],
     "ask": [],

--- a/lib/src/actions/actions.dart
+++ b/lib/src/actions/actions.dart
@@ -4799,11 +4799,14 @@ abstract class OxExportOnlySelectedStrandsSet
 
 abstract class WarnAboutUnassignedDnaAndOxviewOpenSet
     with BuiltJsonSerializable
-    implements Action, Built<WarnAboutUnassignedDnaAndOxviewOpenSet, WarnAboutUnassignedDnaAndOxviewOpenSetBuilder> {
+    implements
+        Action,
+        Built<WarnAboutUnassignedDnaAndOxviewOpenSet, WarnAboutUnassignedDnaAndOxviewOpenSetBuilder> {
   bool get warn;
 
   /************************ begin BuiltValue boilerplate ************************/
-  factory WarnAboutUnassignedDnaAndOxviewOpenSet({required bool warn}) = _$WarnAboutUnassignedDnaAndOxviewOpenSet._;
+  factory WarnAboutUnassignedDnaAndOxviewOpenSet({required bool warn}) =
+      _$WarnAboutUnassignedDnaAndOxviewOpenSet._;
 
   WarnAboutUnassignedDnaAndOxviewOpenSet._();
 
@@ -4816,11 +4819,17 @@ abstract class WarnAboutUnassignedDnaAndOxviewOpenSet
 
 abstract class WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet
     with BuiltJsonSerializable
-    implements Action, Built<WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet, WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSetBuilder> {
+    implements
+        Action,
+        Built<
+          WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet,
+          WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSetBuilder
+        > {
   bool get warn;
 
   /************************ begin BuiltValue boilerplate ************************/
-  factory WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet({required bool warn}) = _$WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet._;
+  factory WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet({required bool warn}) =
+      _$WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet._;
 
   WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet._();
 

--- a/lib/src/actions/actions.dart
+++ b/lib/src/actions/actions.dart
@@ -4797,6 +4797,40 @@ abstract class OxExportOnlySelectedStrandsSet
   int get hashCode;
 }
 
+abstract class WarnAboutUnassignedDnaAndOxviewOpenSet
+    with BuiltJsonSerializable
+    implements Action, Built<WarnAboutUnassignedDnaAndOxviewOpenSet, WarnAboutUnassignedDnaAndOxviewOpenSetBuilder> {
+  bool get warn;
+
+  /************************ begin BuiltValue boilerplate ************************/
+  factory WarnAboutUnassignedDnaAndOxviewOpenSet({required bool warn}) = _$WarnAboutUnassignedDnaAndOxviewOpenSet._;
+
+  WarnAboutUnassignedDnaAndOxviewOpenSet._();
+
+  static Serializer<WarnAboutUnassignedDnaAndOxviewOpenSet> get serializer =>
+      _$warnAboutUnassignedDnaAndOxviewOpenSetSerializer;
+
+  @memoized
+  int get hashCode;
+}
+
+abstract class WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet
+    with BuiltJsonSerializable
+    implements Action, Built<WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet, WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSetBuilder> {
+  bool get warn;
+
+  /************************ begin BuiltValue boilerplate ************************/
+  factory WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet({required bool warn}) = _$WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet._;
+
+  WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet._();
+
+  static Serializer<WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet> get serializer =>
+      _$warnAboutUnassignedDnaOnOxViewOrOxDNAExportSetSerializer;
+
+  @memoized
+  int get hashCode;
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // convert extensions to bound domains on new helix
 

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -267,7 +267,9 @@ class App {
       };
       this.view.oxview_view.frame.contentWindow?.postMessage(message, constants.OXVIEW_URL);
       if (app.state.maybe_design != null) {
-        update_oxview_view(app.state.design, this.view.oxview_view.frame);
+        // Only show warnings if oxView is actually visible to the user
+        bool should_warn = app.state.ui_state.warn_about_unassigned_dna_and_oxview_open && app.state.ui_state.show_oxview;
+        update_oxview_view(app.state.design, this.view.oxview_view.frame, should_warn);
       }
     });
   }

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -268,7 +268,8 @@ class App {
       this.view.oxview_view.frame.contentWindow?.postMessage(message, constants.OXVIEW_URL);
       if (app.state.maybe_design != null) {
         // Only show warnings if oxView is actually visible to the user
-        bool should_warn = app.state.ui_state.warn_about_unassigned_dna_and_oxview_open && app.state.ui_state.show_oxview;
+        bool should_warn =
+            app.state.ui_state.warn_about_unassigned_dna_and_oxview_open && app.state.ui_state.show_oxview;
         update_oxview_view(app.state.design, this.view.oxview_view.frame, should_warn);
       }
     });

--- a/lib/src/middleware/oxdna_export.dart
+++ b/lib/src/middleware/oxdna_export.dart
@@ -52,7 +52,7 @@ First select some strands, or choose Export🡒oxDNA to export all strands in th
             }
           }
         }
-        
+
         if (strand_names_without_dna.isNotEmpty) {
           var msg =
               'The following strands do not have complete DNA sequences assigned: '
@@ -65,7 +65,7 @@ First select some strands, or choose Export🡒oxDNA to export all strands in th
           window.alert(msg);
         }
       }
-      
+
       var (dat, top) = to_oxdna_format(state.design, strands_to_export); // (String, String)
 
       String default_filename = state.ui_state.loaded_filename;
@@ -87,7 +87,7 @@ First select some strands, or choose Export🡒oxDNA to export all strands in th
             }
           }
         }
-        
+
         if (strand_names_without_dna.isNotEmpty) {
           var msg =
               'The following strands do not have complete DNA sequences assigned: '
@@ -100,7 +100,7 @@ First select some strands, or choose Export🡒oxDNA to export all strands in th
           window.alert(msg);
         }
       }
-      
+
       // var start = DateTime.now();
       String content = to_oxview_format(state.design, strands_to_export);
       // print('to_oxview_format: ${DateTime.now().inMilliseconds} ms');

--- a/lib/src/middleware/oxdna_export.dart
+++ b/lib/src/middleware/oxdna_export.dart
@@ -40,6 +40,32 @@ First select some strands, or choose Export🡒oxDNA to export all strands in th
     }
 
     if (action is actions.OxdnaExport) {
+      // Check for unassigned DNA and show warning if enabled
+      if (state.ui_state.warn_about_unassigned_dna_on_export) {
+        List<String> strand_names_without_dna = [];
+        for (var strand in strands_to_export) {
+          if (strand.dna_sequence == null || strand.dna_sequence!.contains(constants.DNA_BASE_WILDCARD)) {
+            if (strand.name != null) {
+              strand_names_without_dna.add(strand.name!);
+            } else {
+              strand_names_without_dna.add(strand.id);
+            }
+          }
+        }
+        
+        if (strand_names_without_dna.isNotEmpty) {
+          var msg =
+              'The following strands do not have complete DNA sequences assigned: '
+              '${strand_names_without_dna.join(", ")}. '
+              'These strands will be exported with a default sequence of "T" '
+              'for each nucleotide whose base is not specified. '
+              'This can lead to unexpected behavior in oxDNA simulations. For best results, '
+              'assign a DNA sequence to each strand before exporting.'
+              '\n\nTo silence this warning, uncheck View→Warnings→Warn about unassigned DNA on oxView/oxDNA export.';
+          window.alert(msg);
+        }
+      }
+      
       var (dat, top) = to_oxdna_format(state.design, strands_to_export); // (String, String)
 
       String default_filename = state.ui_state.loaded_filename;
@@ -49,6 +75,32 @@ First select some strands, or choose Export🡒oxDNA to export all strands in th
       util.save_file(default_filename_dat, dat);
       util.save_file(default_filename_top, top);
     } else if (action is actions.OxviewExport) {
+      // Check for unassigned DNA and show warning if enabled
+      if (state.ui_state.warn_about_unassigned_dna_on_export) {
+        List<String> strand_names_without_dna = [];
+        for (var strand in strands_to_export) {
+          if (strand.dna_sequence == null || strand.dna_sequence!.contains(constants.DNA_BASE_WILDCARD)) {
+            if (strand.name != null) {
+              strand_names_without_dna.add(strand.name!);
+            } else {
+              strand_names_without_dna.add(strand.id);
+            }
+          }
+        }
+        
+        if (strand_names_without_dna.isNotEmpty) {
+          var msg =
+              'The following strands do not have complete DNA sequences assigned: '
+              '${strand_names_without_dna.join(", ")}. '
+              'These strands will be exported with a default sequence of "T" '
+              'for each nucleotide whose base is not specified. '
+              'This can lead to unexpected behavior in oxView. For best results, '
+              'assign a DNA sequence to each strand before exporting.'
+              '\n\nTo silence this warning, uncheck View→Warnings→Warn about unassigned DNA on oxView/oxDNA export.';
+          window.alert(msg);
+        }
+      }
+      
       // var start = DateTime.now();
       String content = to_oxview_format(state.design, strands_to_export);
       // print('to_oxview_format: ${DateTime.now().inMilliseconds} ms');
@@ -129,16 +181,7 @@ String to_oxview_format(Design design, List<Strand> strands_to_export) {
     oxview_strands.add(oxv_strand);
   }
 
-  if (strand_names_without_dna.isNotEmpty) {
-    var msg =
-        'The following strands do not have complete DNA sequences assigned: '
-        '${strand_names_without_dna.join(", ")}. '
-        'These strands will be exported with a default sequence of "T" '
-        'for each nucleotide whose base is not specified. '
-        'This can lead to unexpected behavior in oxView. For best results, '
-        'assign a DNA sequence to each strand before exporting.';
-    window.alert(msg);
-  }
+  // Warning logic moved to oxdna_export middleware
 
   //TODO: this hasn't been tested well
   var base_pairs_map = design.base_pairs_with_domain_strand(

--- a/lib/src/middleware/oxview_update_view.dart
+++ b/lib/src/middleware/oxview_update_view.dart
@@ -39,7 +39,7 @@ void _check_and_show_unassigned_dna_warning(List<Strand> strands_to_export) {
       }
     }
   }
-  
+
   if (strand_names_without_dna.isNotEmpty) {
     var msg =
         'The following strands do not have complete DNA sequences assigned: '
@@ -61,7 +61,7 @@ oxview_update_view_middleware(Store<AppState> store, dynamic action, NextDispatc
 
   if (action is actions.OxviewShowSet) {
     app.view.update_showing_oxview();
-    
+
     // Show warning when user opens oxView (not when closing it)
     if (action.show && store.state.ui_state.warn_about_unassigned_dna_and_oxview_open) {
       if (store.state.maybe_design != null) {
@@ -71,7 +71,11 @@ oxview_update_view_middleware(Store<AppState> store, dynamic action, NextDispatc
   }
 
   if (store.state.ui_state.show_oxview && action is actions.DesignChangingAction) {
-    update_oxview_view(store.state.design, null, store.state.ui_state.warn_about_unassigned_dna_and_oxview_open);
+    update_oxview_view(
+      store.state.design,
+      null,
+      store.state.ui_state.warn_about_unassigned_dna_and_oxview_open,
+    );
   }
 }
 

--- a/lib/src/middleware/oxview_update_view.dart
+++ b/lib/src/middleware/oxview_update_view.dart
@@ -27,6 +27,32 @@ import '../constants.dart' as constants;
 import 'oxdna_export.dart';
 import '../app.dart';
 
+// Helper function to check for unassigned DNA and show warning
+void _check_and_show_unassigned_dna_warning(List<Strand> strands_to_export) {
+  List<String> strand_names_without_dna = [];
+  for (var strand in strands_to_export) {
+    if (strand.dna_sequence == null || strand.dna_sequence!.contains(constants.DNA_BASE_WILDCARD)) {
+      if (strand.name != null) {
+        strand_names_without_dna.add(strand.name!);
+      } else {
+        strand_names_without_dna.add(strand.id);
+      }
+    }
+  }
+  
+  if (strand_names_without_dna.isNotEmpty) {
+    var msg =
+        'The following strands do not have complete DNA sequences assigned: '
+        '${strand_names_without_dna.join(", ")}. '
+        'These strands will be exported with a default sequence of "T" '
+        'for each nucleotide whose base is not specified. '
+        'This can lead to unexpected behavior in oxView. For best results, '
+        'assign a DNA sequence to each strand before exporting.'
+        '\n\nTo silence this warning, uncheck View→Warnings→Warn about unassigned DNA if oxView open.';
+    window.alert(msg);
+  }
+}
+
 // This middleware handles sending the new design to the oxview viewer,
 // as well as updating whether it is shown, since it is wired to the
 // view outside of React.
@@ -35,10 +61,17 @@ oxview_update_view_middleware(Store<AppState> store, dynamic action, NextDispatc
 
   if (action is actions.OxviewShowSet) {
     app.view.update_showing_oxview();
+    
+    // Show warning when user opens oxView (not when closing it)
+    if (action.show && store.state.ui_state.warn_about_unassigned_dna_and_oxview_open) {
+      if (store.state.maybe_design != null) {
+        _check_and_show_unassigned_dna_warning(store.state.design.strands.toList());
+      }
+    }
   }
 
   if (store.state.ui_state.show_oxview && action is actions.DesignChangingAction) {
-    update_oxview_view(store.state.design);
+    update_oxview_view(store.state.design, null, store.state.ui_state.warn_about_unassigned_dna_and_oxview_open);
   }
 }
 
@@ -46,7 +79,7 @@ oxview_update_view_middleware(Store<AppState> store, dynamic action, NextDispatc
 // but on startup, `app.view` is not yet initialized (we're in the View constructor
 // the first time we call `update_oxview_view`), so from that constructor, we send the frame explicitly
 // to this function just after creating it, but before it can be accessed via `app.view.oxview_view?.frame`.
-void update_oxview_view(Design design, [IFrameElement? frame = null]) {
+void update_oxview_view(Design design, IFrameElement? frame, bool warn_enabled) {
   if (frame == null) {
     frame = app.view.oxview_view.frame;
   }
@@ -64,6 +97,8 @@ void update_oxview_view(Design design, [IFrameElement? frame = null]) {
 
   // send current exported design
   List<Strand> strands_to_export = design.strands.toList();
+
+  // Warning handled in middleware, not here
 
   //////////////////////////////////////////
   // oxDNA

--- a/lib/src/reducers/app_ui_state_reducer.dart
+++ b/lib/src/reducers/app_ui_state_reducer.dart
@@ -299,6 +299,12 @@ bool export_svg_text_separately_reducer(bool _, actions.ExportSvgTextSeparatelyS
 bool ox_export_only_selected_strands_reducer(bool _, actions.OxExportOnlySelectedStrandsSet action) =>
     action.only_selected;
 
+bool warn_about_unassigned_dna_and_oxview_open_reducer(bool _, actions.WarnAboutUnassignedDnaAndOxviewOpenSet action) =>
+    action.warn;
+
+bool warn_about_unassigned_dna_on_oxview_or_oxdna_export_reducer(bool _, actions.WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet action) =>
+    action.warn;
+
 bool display_major_tick_widths_reducer(bool _, actions.SetDisplayMajorTickWidths action) => action.show;
 
 bool strand_paste_keep_color_reducer(bool _, actions.StrandPasteKeepColorSet action) => action.keep;
@@ -651,6 +657,12 @@ AppUIStateStorables app_ui_state_storable_local_reducer(AppUIStateStorables stor
           ..ox_export_only_selected_strands = TypedReducer<bool, actions.OxExportOnlySelectedStrandsSet>(
             ox_export_only_selected_strands_reducer,
           )(storables.ox_export_only_selected_strands, action)
+          ..warn_about_unassigned_dna_and_oxview_open = TypedReducer<bool, actions.WarnAboutUnassignedDnaAndOxviewOpenSet>(
+            warn_about_unassigned_dna_and_oxview_open_reducer,
+          )(storables.warn_about_unassigned_dna_and_oxview_open, action)
+          ..warn_about_unassigned_dna_on_export = TypedReducer<bool, actions.WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet>(
+            warn_about_unassigned_dna_on_oxview_or_oxdna_export_reducer,
+          )(storables.warn_about_unassigned_dna_on_export, action)
           ..only_display_selected_helices = TypedReducer<bool, actions.SetOnlyDisplaySelectedHelices>(
             only_display_selected_helices_reducer,
           )(storables.only_display_selected_helices, action)

--- a/lib/src/reducers/app_ui_state_reducer.dart
+++ b/lib/src/reducers/app_ui_state_reducer.dart
@@ -299,11 +299,15 @@ bool export_svg_text_separately_reducer(bool _, actions.ExportSvgTextSeparatelyS
 bool ox_export_only_selected_strands_reducer(bool _, actions.OxExportOnlySelectedStrandsSet action) =>
     action.only_selected;
 
-bool warn_about_unassigned_dna_and_oxview_open_reducer(bool _, actions.WarnAboutUnassignedDnaAndOxviewOpenSet action) =>
-    action.warn;
+bool warn_about_unassigned_dna_and_oxview_open_reducer(
+  bool _,
+  actions.WarnAboutUnassignedDnaAndOxviewOpenSet action,
+) => action.warn;
 
-bool warn_about_unassigned_dna_on_oxview_or_oxdna_export_reducer(bool _, actions.WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet action) =>
-    action.warn;
+bool warn_about_unassigned_dna_on_oxview_or_oxdna_export_reducer(
+  bool _,
+  actions.WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet action,
+) => action.warn;
 
 bool display_major_tick_widths_reducer(bool _, actions.SetDisplayMajorTickWidths action) => action.show;
 
@@ -657,12 +661,14 @@ AppUIStateStorables app_ui_state_storable_local_reducer(AppUIStateStorables stor
           ..ox_export_only_selected_strands = TypedReducer<bool, actions.OxExportOnlySelectedStrandsSet>(
             ox_export_only_selected_strands_reducer,
           )(storables.ox_export_only_selected_strands, action)
-          ..warn_about_unassigned_dna_and_oxview_open = TypedReducer<bool, actions.WarnAboutUnassignedDnaAndOxviewOpenSet>(
-            warn_about_unassigned_dna_and_oxview_open_reducer,
-          )(storables.warn_about_unassigned_dna_and_oxview_open, action)
-          ..warn_about_unassigned_dna_on_export = TypedReducer<bool, actions.WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet>(
-            warn_about_unassigned_dna_on_oxview_or_oxdna_export_reducer,
-          )(storables.warn_about_unassigned_dna_on_export, action)
+          ..warn_about_unassigned_dna_and_oxview_open =
+              TypedReducer<bool, actions.WarnAboutUnassignedDnaAndOxviewOpenSet>(
+                warn_about_unassigned_dna_and_oxview_open_reducer,
+              )(storables.warn_about_unassigned_dna_and_oxview_open, action)
+          ..warn_about_unassigned_dna_on_export =
+              TypedReducer<bool, actions.WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet>(
+                warn_about_unassigned_dna_on_oxview_or_oxdna_export_reducer,
+              )(storables.warn_about_unassigned_dna_on_export, action)
           ..only_display_selected_helices = TypedReducer<bool, actions.SetOnlyDisplaySelectedHelices>(
             only_display_selected_helices_reducer,
           )(storables.only_display_selected_helices, action)

--- a/lib/src/state/app_ui_state.dart
+++ b/lib/src/state/app_ui_state.dart
@@ -243,6 +243,10 @@ abstract class AppUIState with BuiltJsonSerializable implements Built<AppUIState
 
   bool get ox_export_only_selected_strands => storables.ox_export_only_selected_strands;
 
+  bool get warn_about_unassigned_dna_and_oxview_open => storables.warn_about_unassigned_dna_and_oxview_open;
+
+  bool get warn_about_unassigned_dna_on_export => storables.warn_about_unassigned_dna_on_export;
+
   static void _initializeBuilder(AppUIStateBuilder b) {
     b.copy_info = null;
     b.last_mod_5p = null;

--- a/lib/src/state/app_ui_state_storables.dart
+++ b/lib/src/state/app_ui_state_storables.dart
@@ -135,6 +135,10 @@ abstract class AppUIStateStorables
 
   bool get ox_export_only_selected_strands;
 
+  bool get warn_about_unassigned_dna_and_oxview_open;
+
+  bool get warn_about_unassigned_dna_on_export;
+
   static void _initializeBuilder(AppUIStateStorablesBuilder b) {
     // This ensures that even if these keys are not in localStorage (e.g., due to upgrading),
     // then they will be populated with a default value instead of raising an exception.
@@ -196,6 +200,8 @@ abstract class AppUIStateStorables
     b.selection_box_intersection = false;
     b.export_svg_text_separately = false;
     b.ox_export_only_selected_strands = false;
+    b.warn_about_unassigned_dna_and_oxview_open = true;
+    b.warn_about_unassigned_dna_on_export = true;
   }
 
   /************************ begin BuiltValue boilerplate ************************/

--- a/lib/src/view/menu.dart
+++ b/lib/src/view/menu.dart
@@ -728,6 +728,34 @@ strand at the same (helix,offset).'''
           );
         }
         ..key = 'show-unpaired-insertion-deletions')(),
+      (MenuBoolean()
+        ..value = props.state.ui_state.warn_about_unassigned_dna_and_oxview_open
+        ..display = 'Warn about unassigned DNA if oxView open'
+        ..tooltip = '''\
+If checked, when oxView view is open and unassigned DNA sequences are detected, 
+a warning popup will appear. This warning only appears when oxView is open.
+If unchecked, the warning will not appear.'''
+        ..on_change =
+            ((_) => app.dispatch(
+              actions.WarnAboutUnassignedDnaAndOxviewOpenSet(
+                warn: !props.state.ui_state.warn_about_unassigned_dna_and_oxview_open,
+              ),
+            ))
+        ..key = 'warn-about-unassigned-dna')(),
+      (MenuBoolean()
+        ..value = props.state.ui_state.warn_about_unassigned_dna_on_export
+        ..display = 'Warn about unassigned DNA on oxView/oxDNA export'
+        ..tooltip = '''\
+If checked, when exporting to oxView or oxDNA and unassigned DNA sequences are detected, 
+a warning popup will appear.
+If unchecked, the warning will not appear.'''
+        ..on_change =
+            ((_) => app.dispatch(
+              actions.WarnAboutUnassignedDnaOnOxViewOrOxDNAExportSet(
+                warn: !props.state.ui_state.warn_about_unassigned_dna_on_export,
+              ),
+            ))
+        ..key = 'warn-about-unassigned-dna-on-export')(),
     ]);
   }
 


### PR DESCRIPTION
Made warnings about unassigned DNA optional when exporting to oxview and oxDNA and showing oxView view.