### PR TITLE
Fixes #1081 - Update Dart SDK and Standalone Actions

### DIFF
--- a/.github/actions/setup-dart/action.yml
+++ b/.github/actions/setup-dart/action.yml
@@ -1,0 +1,11 @@
+name: Setup Dart SDK
+inputs:
+  sdk:
+    default: "3.11"
+    description: The Dart SDK to use. Defaults to 3.11 if none is provided.
+runs:
+  using: composite
+  steps:
+    - uses: dart-lang/setup-dart@v1
+      with:
+        sdk: ${{ inputs.sdk }}

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -14,9 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
-        with:
-          sdk: 3.11
+        uses: ./.github/actions/setup-dart
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/dart_formatting.yml
+++ b/.github/workflows/dart_formatting.yml
@@ -13,10 +13,8 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v4
 
-      - name: Setup Dart SDK  # Using Dart 3.8 to match pubspec.yaml constraint
-        uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
-        with:
-          sdk: 3.11
+      - name: Setup Dart SDK
+        uses: ./.github/actions/setup-dart
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/gh-pages-dev.yml
+++ b/.github/workflows/gh-pages-dev.yml
@@ -20,10 +20,8 @@ jobs:
           ref: gh-pages
           path: gh-pages-repo
 
-      - name: Setup Dart SDK  # Using Dart 3.8 to match pubspec.yaml constraint
-        uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
-        with:
-          sdk: 3.11
+      - name: Setup Dart SDK
+        uses: ./.github/actions/setup-dart
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,10 +19,8 @@ jobs:
           ref: gh-pages
           path: gh-pages-repo
 
-      - name: Setup Dart SDK  # Using Dart 3.8 to match pubspec.yaml constraint
-        uses: dart-lang/setup-dart@v1  # https://github.com/dart-lang/setup-dart
-        with:
-          sdk: 3.11
+      - name: Setup Dart SDK
+        uses: ./.github/actions/setup-dart
 
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/release-and-upload-artifacts.yml
+++ b/.github/workflows/release-and-upload-artifacts.yml
@@ -45,10 +45,10 @@ jobs:
     steps:
       # Setup Builder
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
 
       - name: Setup Dart SDK
         uses: ./.github/actions/setup-dart

--- a/.github/workflows/release-and-upload-artifacts.yml
+++ b/.github/workflows/release-and-upload-artifacts.yml
@@ -53,11 +53,6 @@ jobs:
       - name: Setup Dart SDK
         uses: ./.github/actions/setup-dart
 
-      - name: Build generated files for sub-packages
-        run: |
-          cd scadnano_state_actions && dart run build_runner build --delete-conflicting-outputs && cd ..
-          cd scadnano_reducers && dart run build_runner build --delete-conflicting-outputs && cd ..
-
       - name: Install ImageMagick
         shell: bash
         run: |

--- a/.github/workflows/release-and-upload-artifacts.yml
+++ b/.github/workflows/release-and-upload-artifacts.yml
@@ -44,11 +44,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       # Setup Builder
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: 3.8
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Setup Dart SDK
+        uses: ./.github/actions/setup-dart
+
+      - name: Build generated files for sub-packages
+        run: |
+          cd scadnano_state_actions && dart run build_runner build --delete-conflicting-outputs && cd ..
+          cd scadnano_reducers && dart run build_runner build --delete-conflicting-outputs && cd ..
 
       - name: Install ImageMagick
         shell: bash

--- a/.github/workflows/release-and-upload-artifacts.yml
+++ b/.github/workflows/release-and-upload-artifacts.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 1 # reduce from 90-day default. This is only required for passing artifacts between jobs.
           name: build-${{ matrix.os }}
           path: |
             standalone/dist/scadnano*.*

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -45,7 +45,10 @@
     }
   },
   "scripts": {
-    "init": "cd .. && dart pub get && dart pub global activate webdev && webdev build -- --delete-conflicting-outputs",
+    "init": "npm run setup:state_actions && npm run setup:reducers && npm run setup:webdev",
+    "setup:webdev": "cd .. && dart pub get && dart pub global activate webdev && webdev build -- --delete-conflicting-outputs",
+    "setup:state_actions": "cd .. && dart pub get && cd scadnano_state_actions && dart run build_runner build --delete-conflicting-outputs",
+    "setup:reducers": "cd .. && dart pub get && cd scadnano_reducers && dart run build_runner build --delete-conflicting-outputs",
     "dev": "npm run init && electron-forge start",
     "package": "electron-builder --dir",
     "build:win": "npm run init && electron-builder --win --publish never",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Updates the Dart SDK action to be reusable. This means that instead of changing the Dart SDK for each of the actions files individually, you now only need to change one action file located here: `.github/actions/setup-dart/action.yml`. You can also optionally specify the SDK manually should you want to use a different one.
* Added the reusable dart actions to the normal CI/CD actions files.
* I discovered a bug with the standalone `package.json`, something seems to have changed between Dart 3.8 and 3.11, meaning that the reducers and state actions would not get compiled automatically like before. This has now been fixed and should be able to be run correctly.

> Note: To prevent something like this in the future, it may be worth adding an action in the same way that we run unit tests on every PR to just simply build the artifact for at least 1 operating system. That way we can know at PR-time whether or not the artifacts build. However, building artifacts can take up a significant amount of time.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1081.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was required because the automatic executable files were not able to be generated unless the actions completed. Furthermore, this allows easier updates to the Dart SDK action in the future by only requiring one file change, rather than multiple.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1) Created a fork of this repository and ran the changes on my own fork. Executables were successfully attached to the new release.
2) Ran the development branch on my own local machine for the standalone version.

## Screenshots (if appropriate):
N/A