### PR TITLE
bump electron from 35.1.3 to 39.8.x

### DIFF
--- a/standalone/package-lock.json
+++ b/standalone/package-lock.json
@@ -20,7 +20,7 @@
         "@electron-forge/plugin-auto-unpack-natives": "^7.7.0",
         "@electron-forge/plugin-fuses": "^7.7.0",
         "@electron/fuses": "^2.1.3",
-        "electron": "^35.0.0",
+        "electron": "^39.8.5",
         "electron-builder": "^26.8.1"
       }
     },
@@ -3855,9 +3855,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "35.1.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-35.1.3.tgz",
-      "integrity": "sha512-z7zZtvoK40ynKmgZ5dfD5xhsAXHxNShWgx9vIpC/ZMawBB93sBTWU83gHrjSzAcY9n0Io1WJCyUt/UIQHzlDXA==",
+      "version": "39.8.10",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.10.tgz",
+      "integrity": "sha512-zbYtGPYUI7PzqLAzkk21Rk6j67WN0hxn0Mq/njErZo1d0HSf33is4f8ICI5fMLy5vYe0JtCtM5sYunNOaochSQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -86,7 +86,7 @@
     "@electron-forge/plugin-auto-unpack-natives": "^7.7.0",
     "@electron-forge/plugin-fuses": "^7.7.0",
     "@electron/fuses": "^2.1.3",
-    "electron": "^35.0.0",
+    "electron": "^39.8.5",
     "electron-builder": "^26.8.1"
   },
   "dependencies": {


### PR DESCRIPTION
Replaces #1077, which dependabot cannot rebase (see below). Same change, produced by hand:
`electron` `^35.0.0` → `^39.8.5`, which locks **39.8.10**.

## Why not just rebase #1077

It was opened 2026-04-07, before `target-branch: dev` existed for the npm ecosystem, so its branch is
`dependabot/npm_and_yarn/standalone/electron-39.8.5` rather than `.../standalone/dev/...`. After I retargeted
it to `dev` by hand it stopped matching any entry in `dependabot.yml`, and dependabot replied:

> The dependabot.yml entry that created this PR has been deleted so this PR can't be rebased. Please close the PR so Dependabot can create a new one.

## ⚠️ CI cannot validate this one

`build-and-deploy.yml` **packages** the app but never **launches** it. An Electron build that fails to start
passes every check green. This is four Chromium majors (134 → 142), so green CI is necessary but nowhere near
sufficient.

After merging, download the `dev-latest` executables and check on **each** of Windows, macOS and Linux:

- [ ] **The window loads at all.** `main.js` does `win.loadFile('../build/index.html')` through the asar. A
      blank white window means that load or the dart2js bundle failed — uncomment
      `win.webContents.openDevTools()` in `main.js` and read the console.
- [ ] **File → Open** reaches the native dialog. Electron 36 made **GTK 4 the default under GNOME**; symptoms
      are no dialog, a dialog behind the window, or a crash. Mitigation if needed:
      `app.commandLine.appendSwitch('gtk-version', '3')`.
- [ ] **Save design / export SVG / export PNG** actually write a file (these go through
      `Url.createObjectUrlFromBlob` + `AnchorElement..download`).
- [ ] **A design survives quit and relaunch** — localStorage under a `file://` origin. Chromium's storage
      partitioning changed across these versions, and the failure mode (users silently lose autosaved work) is
      the worst one here.
- [ ] **Linux on Wayland** (Ubuntu 24.04+/Fedora GNOME) — Electron 38 flipped `--ozone-platform` to `auto`.
      Check all three of AppImage / deb / rpm. Mitigation: `--ozone-platform=x11`.
- [ ] **macOS**: the universal dmg launches on both Intel and Apple Silicon.

## Release note needed

**Electron 38 dropped macOS 11 (Big Sur).** Those users' next update will simply not launch, with no
diagnostic. That belongs in the release notes for whichever version ships this, not in a bug report later.

## Do not misattribute this pre-existing bug

The unsaved-changes exit warning is *already* broken on `dev`: `main.js` calls `event.preventDefault()` after
an `await`, which is past the synchronous dispatch, and `window.warnOnExit` is only assigned inside the
`onBeforeUnload` listener while Electron fires `close` before DOM `beforeunload`. If the exit warning does not
appear, that is not Electron 39.
